### PR TITLE
fix for #20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 # Package metadata
 name = "suql"
-version = "1.1.7a1"
+version = "1.1.7a2"
 description = "Structured and Unstructured Query Language (SUQL) Python API"
 author = "Shicheng Liu"
 author_email = "shicheng@cs.stanford.edu"


### PR DESCRIPTION
Three issues were identified and fixed:

1. For some reason, `pglast.enums.nodes.LimitOption.LIMIT_OPTION_COUNT` has to be used so that during SQL serialization, it does not omit the LIMIT clause (this is actually unrelated to #20 but was found and fixed during debugging);
2. The immediate culprit for #20 was due to line `node = deepcopy(original_node)`. It seems that adding a serialization step before this line (`_ = RawStream()(original_node)`) fixes the problem. This could stem from some recursive structure within the node that would get cleaned up after a serialization;
3. Previously, `_Replace_Original_Target_Visitor` is repeatedly called, even after the projections have already been changed. This would lead to `None` in the selection clauses. This has been fixed with checking if `^` is already in `JOIN`, and if so, skip the conversion step.

Hereby releasing `1.1.7a2`.