### PR TITLE
fix for #19

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 # Package metadata
 name = "suql"
-version = "1.1.7a2"
+version = "1.1.7a3"
 description = "Structured and Unstructured Query Language (SUQL) Python API"
 author = "Shicheng Liu"
 author_email = "shicheng@cs.stanford.edu"

--- a/src/suql/faiss_embedding.py
+++ b/src/suql/faiss_embedding.py
@@ -301,6 +301,8 @@ class EmbeddingStore:
                 params=faiss.SearchParametersIVF(sel=sel),
             )
         else:
+            if top > self.embeddings.ntotal:
+                top = self.embeddings.ntotal
             D, I = self.embeddings.search(
                 query_embedding, top, params=faiss.SearchParametersIVF(sel=sel)
             )


### PR DESCRIPTION
One issue was identified and fixed:

1. In the embedding code, if `top > self.embeddings.ntotal`, previously `faiss` would patch the result array with `-1` until it fills `top`. This would crash the code. Fix is to introduce a checker to see if `top` is larger than `self.embeddings.ntotal` and if so change `top`.