### PR TITLE
fix(compiler): support CTEs mixing answer()/summary() with structural SQL (#45)

### DIFF
--- a/src/suql/sql_free_text_support/execute_free_text_sql.py
+++ b/src/suql/sql_free_text_support/execute_free_text_sql.py
@@ -10,7 +10,7 @@ import traceback
 from collections import defaultdict
 from copy import deepcopy
 from functools import lru_cache
-from typing import List, Union
+from typing import Dict, List, Union
 from uuid import uuid4
 
 import pglast
@@ -259,12 +259,38 @@ class _SelectVisitor(Visitor):
         # subqueries and emits spurious probe SQLs there (see issue #52).
         self.enable_classifier = enable_classifier
 
+        # CTE column lineage: maps a CTE name (and its temp table name once
+        # materialized) to {projected_col_name: (underlying_real_table, real_col)}.
+        # Used to rewrite (cte_name, col) → (real_table, real_col) in
+        # breakdown_unstructural_query so the embedding server can find the
+        # correct FAISS index (which is keyed by real-table name).
+        self.cte_column_lineage: Dict[str, Dict[str, tuple]] = {}
+
+        # Cache of real-table column lists for lineage building, keyed by
+        # relname. Populated lazily via _get_table_columns().
+        self._table_columns_cache: Dict[str, list] = {}
+
     def __call__(self, node):
         super().__call__(node)
 
     def visit_SelectStmt(self, ancestors, node: SelectStmt):
         type_cast_answer_visitor = _TypeCastAnswer()
         type_cast_answer_visitor(node)
+
+        # Handle WITH clause before the outer query so that any answer() inside
+        # the outer's whereClause can resolve CTE references. Mirrors the
+        # SubLink "process inner first" pattern below.
+        if node.withClause is not None:
+            if node.withClause.recursive:
+                if any(_if_contains_free_text_fcn(c.ctequery) for c in node.withClause.ctes):
+                    raise NotImplementedError(
+                        "SUQL does not support WITH RECURSIVE containing answer()/summary(). "
+                        "Non-recursive CTEs are supported, and WITH RECURSIVE without LLM "
+                        "calls is left for Postgres to evaluate natively."
+                    )
+                # Recursive CTE with no answer() — let Postgres handle it.
+            else:
+                self._process_ctes(node)
 
         if not node.whereClause:
             return
@@ -282,7 +308,6 @@ class _SelectVisitor(Visitor):
 
         if freeTextFcnVisitor.res:
             tmp_table_name = "temp_table_{}".format(_generate_random_string())
-            self.tmp_tables.append(tmp_table_name)
 
             # main entry point for SUQL compiler optimization
             results, column_info = _analyze_SelectStmt(
@@ -300,6 +325,7 @@ class _SelectVisitor(Visitor):
                 self.api_version,
                 self.api_key,
                 disable_retriever=self.disable_retriever,
+                cte_column_lineage=self.cte_column_lineage,
                 enable_classifier=self.enable_classifier,
             )
 
@@ -319,6 +345,12 @@ class _SelectVisitor(Visitor):
                 host=self.host,
                 port=self.port,
             )
+            # Register for cleanup only after CREATE TABLE has succeeded. If
+            # _analyze_SelectStmt raises mid-flight (e.g., the CTE lineage
+            # tracker refuses a computed-expression answer() target), the
+            # name would otherwise be in self.tmp_tables and drop_tmp_tables
+            # would try to DROP a table that never existed.
+            self.tmp_tables.append(tmp_table_name)
 
             if results:
                 # some special processing is needed for python dict types - they need to be converted to json
@@ -367,6 +399,407 @@ class _SelectVisitor(Visitor):
                 self.host,
                 self.port,
             )
+
+    def _process_ctes(self, node: SelectStmt):
+        """Process non-recursive CTEs in dependency order so the outer query
+        (and downstream CTEs) can resolve references that go through the
+        existing answer()/temp-table machinery.
+
+        Mirrors the SubLink pattern in visit_SelectStmt (process inner first,
+        then outer). Differences from SubLink: CTEs have explicit names and
+        explicit cross-CTE dependencies, so we need a dependency graph + topo
+        sort + RangeVar.relname rewriting on top of the same recursion.
+
+        Materialization set: a CTE is materialized into a temp table iff it
+        contains answer()/summary() OR it is depended on (transitively) by
+        another CTE we'll materialize. CTEs that are neither stay in the WITH
+        clause for Postgres to handle natively; we still register their ID
+        column so outer answer() queries against them can dedup.
+        """
+        ctes = list(node.withClause.ctes)
+        cte_names = {c.ctename for c in ctes}
+        cte_by_name = {c.ctename: c for c in ctes}
+
+        deps = {c.ctename: self._find_cte_refs(c.ctequery, cte_names) for c in ctes}
+        order = self._topo_order_ctes(ctes, deps)
+
+        # Seed: CTEs whose body contains answer()/summary(). Expand to closure
+        # under deps so every dependency of a materialized CTE is also
+        # materialized (otherwise the SUQL pipeline can't resolve them when
+        # it runs the CTE body standalone).
+        needs_mat = {c.ctename for c in ctes if _if_contains_free_text_fcn(c.ctequery)}
+        changed = True
+        while changed:
+            changed = False
+            for name in list(needs_mat):
+                for dep in deps[name]:
+                    if dep not in needs_mat:
+                        needs_mat.add(dep)
+                        changed = True
+
+        # CTE name -> temp table name (only for materialized CTEs).
+        cte_to_tmp: Dict[str, str] = {}
+
+        for name in order:
+            cte = cte_by_name[name]
+            # Rewrite intra-WITH references in this body to point at the temp
+            # tables of already-materialized CTEs. Without this, a body like
+            # `SELECT * FROM base` won't resolve when SUQL runs it standalone
+            # (its surrounding WITH lives on the OUTER SelectStmt).
+            self._rewrite_cte_refs(cte.ctequery, cte_to_tmp)
+
+            id_col = self._infer_cte_id_column(cte.ctequery)
+            # Build column lineage from the (now rewritten) body. Composes
+            # through self.cte_column_lineage for sources that are
+            # already-processed CTEs.
+            lineage = self._build_cte_column_lineage(cte.ctequery)
+            # Register under the CTE name immediately so chained CTEs can
+            # compose their lineage through this one in the same loop.
+            self.cte_column_lineage[name] = lineage
+
+            if name in needs_mat:
+                if _if_contains_free_text_fcn(cte.ctequery):
+                    # Body has answer(); the natural visit_SelectStmt path
+                    # creates a temp table and rewrites the body in place.
+                    self.visit_SelectStmt(None, cte.ctequery)
+                else:
+                    # Body has no answer() but a downstream CTE does and
+                    # references this one. Materialize directly via plain
+                    # Postgres so the downstream's SUQL pipeline can resolve
+                    # `FROM <this_cte>` once we rewrite it.
+                    self._materialize_cte_body_directly(cte.ctequery)
+
+                from_cls = cte.ctequery.fromClause
+                if (from_cls and len(from_cls) == 1
+                        and isinstance(from_cls[0], RangeVar)
+                        and from_cls[0].relname.startswith("temp_table_")):
+                    tmp_name = from_cls[0].relname
+                    cte_to_tmp[name] = tmp_name
+                    # Also register lineage under the temp table name so
+                    # cross-CTE refs (which target the temp name after our
+                    # rewrite) compose correctly.
+                    self.cte_column_lineage[tmp_name] = lineage
+                    if id_col is not None:
+                        self.table_w_ids[tmp_name] = id_col
+
+            # Register the CTE name itself (materialized or not) so the outer
+            # query's _retrieve_and_verify can dedup when it sees
+            # `FROM <cte_name>`.
+            if id_col is not None:
+                self.table_w_ids[name] = id_col
+
+    def _materialize_cte_body_directly(self, body: SelectStmt):
+        """For a CTE with no answer()/summary() that needs to be materialized
+        because something downstream depends on it: `CREATE TABLE temp_xxx AS
+        <body>` and rewrite `body` in place to `SELECT * FROM temp_xxx`."""
+        tmp = "temp_table_{}".format(_generate_random_string())
+        self.tmp_tables.append(tmp)
+        body_sql = RawStream()(body)
+        create_stmt = (
+            f"CREATE TABLE {tmp} AS {body_sql}; "
+            f"GRANT SELECT ON {tmp} TO {self.select_username};"
+        )
+        execute_sql(
+            create_stmt,
+            self.database,
+            user=self.create_username,
+            password=self.create_userpswd,
+            commit_in_lieu_fetch=True,
+            no_print=True,
+            host=self.host,
+            port=self.port,
+        )
+        body.fromClause = (RangeVar(relname=tmp, inh=True, relpersistence="p"),)
+        body.targetList = (ResTarget(val=ColumnRef(fields=(A_Star(),))),)
+        body.whereClause = None
+        body.withClause = None
+        body.limitCount = None
+        body.limitOffset = None
+        body.groupClause = None
+        body.havingClause = None
+        body.sortClause = None
+
+    @staticmethod
+    def _find_cte_refs(body, cte_names):
+        """Return the subset of `cte_names` that `body` references via a
+        bare-name RangeVar (i.e., something Postgres would resolve to a CTE
+        rather than a real table)."""
+        found = set()
+
+        class _Finder(Visitor):
+            def visit_RangeVar(self, ancestors, node):
+                if (node.schemaname is None and node.catalogname is None
+                        and node.relname in cte_names):
+                    found.add(node.relname)
+
+        _Finder()(body)
+        return found
+
+    @staticmethod
+    def _topo_order_ctes(ctes, deps):
+        """Kahn's algorithm. Preserves the user's declaration order for ties.
+        Raises ValueError on cycles (invalid SQL anyway)."""
+        in_degree = {c.ctename: 0 for c in ctes}
+        rev = {c.ctename: [] for c in ctes}
+        for name, depset in deps.items():
+            for d in depset:
+                if d != name:           # self-references handled by recursive
+                    in_degree[name] += 1
+                    rev[d].append(name)
+        ready = [c.ctename for c in ctes if in_degree[c.ctename] == 0]
+        order = []
+        i = 0
+        while i < len(ready):
+            n = ready[i]
+            i += 1
+            order.append(n)
+            for m in rev[n]:
+                in_degree[m] -= 1
+                if in_degree[m] == 0:
+                    ready.append(m)
+        if len(order) != len(ctes):
+            raise ValueError("CTE dependency cycle detected")
+        return order
+
+    @staticmethod
+    def _rewrite_cte_refs(body, mapping):
+        """Replace `RangeVar.relname` with `mapping[relname]` wherever the
+        relname is a key in `mapping`. In-place AST mutation."""
+        if not mapping:
+            return
+
+        class _Rewriter(Visitor):
+            def visit_RangeVar(self, ancestors, node):
+                if (node.schemaname is None and node.catalogname is None
+                        and node.relname in mapping):
+                    node.relname = mapping[node.relname]
+
+        _Rewriter()(body)
+
+    def _infer_cte_id_column(self, body):
+        """Best-effort: figure out which row-ID column this CTE's temp table
+        will carry, so we can register it in table_w_ids.
+
+        Strategy: look at the body's fromClause to find candidate underlying
+        tables. For each table whose ID column we know via self.table_w_ids,
+        check whether that ID is reachable via the body's projection (`*`,
+        `t.*`, bare id, or `t.id`). Return the first match. Returns None if
+        nothing can be safely inferred — in which case the CTE name simply
+        won't be registered, and a downstream `answer()` on it will surface a
+        clear KeyError rather than wrong dedup.
+
+        Mangling: when the body's FROM is a join (JoinExpr) or a multi-table
+        tuple AND the body contains an answer()/summary() call, the temp
+        table created by _execute_structural_sql's join branch carries
+        `^`-mangled column names (e.g. `events^event_id_cnty`) — the same
+        scheme used by _retrieve_and_verify's JoinExpr branch. The inferred
+        ID must match that, otherwise downstream lookups fail.
+        """
+        if not body.fromClause:
+            return None
+        candidates = []
+        has_join_expr = False
+        for f in body.fromClause:
+            if isinstance(f, RangeVar):
+                candidates.append(f)
+            elif isinstance(f, JoinExpr):
+                candidates.extend(_extract_recursive_joins(f))
+                has_join_expr = True
+        is_multi_table = len(body.fromClause) > 1
+        will_mangle = (has_join_expr or is_multi_table) and _if_contains_free_text_fcn(body)
+        target_list = body.targetList or ()
+        for rv in candidates:
+            tname = rv.alias.aliasname if rv.alias is not None else rv.relname
+            if rv.relname not in self.table_w_ids:
+                continue
+            id_col = self.table_w_ids[rv.relname]
+            if self._projection_includes(target_list, tname, id_col):
+                if will_mangle:
+                    return f"{rv.relname}^{id_col}"
+                return id_col
+        return None
+
+    @staticmethod
+    def _projection_includes(target_list, table_qualifier, col):
+        """Does this targetList project `col` (either bare or as `t.col`),
+        or include a star (`*` or `t.*`) that would cover it?"""
+        for rt in target_list:
+            if not isinstance(rt, ResTarget):
+                continue
+            v = rt.val
+            if isinstance(v, ColumnRef):
+                fields = v.fields
+                if len(fields) == 1:
+                    f = fields[0]
+                    if isinstance(f, A_Star):
+                        return True
+                    if isinstance(f, String) and f.sval == col:
+                        return True
+                elif len(fields) == 2 and isinstance(fields[0], String):
+                    qual = fields[0].sval
+                    second = fields[1]
+                    if qual != table_qualifier:
+                        continue
+                    if isinstance(second, A_Star):
+                        return True
+                    if isinstance(second, String) and second.sval == col:
+                        return True
+        return False
+
+    def _get_table_columns(self, relname):
+        """Return the column list for a real Postgres table (cached).
+        For tables we've already processed as CTEs, return the keys of
+        their lineage map. Returns None if neither path is available."""
+        if relname in self._table_columns_cache:
+            return self._table_columns_cache[relname]
+        if relname in self.cte_column_lineage:
+            cols = list(self.cte_column_lineage[relname].keys())
+            self._table_columns_cache[relname] = cols
+            return cols
+        try:
+            _, column_info = execute_sql_with_column_info(
+                f"SELECT * FROM {relname} LIMIT 0",
+                self.database,
+                user=self.select_username,
+                password=self.select_userpswd,
+                host=self.host,
+                port=self.port,
+            )
+            cols = [c[0] for c in column_info]
+        except Exception:
+            cols = None
+        self._table_columns_cache[relname] = cols
+        return cols
+
+    def _build_cte_column_lineage(self, body):
+        """Build a column-lineage map for a CTE body: for each projected
+        column, determine the underlying (real_table, real_col) it traces
+        back to. Returns {projected_col_name: (real_table, real_col)}.
+
+        Skips computed expressions and any column whose source can't be
+        resolved — gaps are filled with None. The lineage is consulted by
+        breakdown_unstructural_query to rewrite the retriever's field
+        tuple from (cte_name, col) → (real_table, real_col); without an
+        entry, the retriever-on path raises NotImplementedError.
+
+        Lineage composition: if the source is itself a CTE we already
+        processed, we inherit through self.cte_column_lineage to find
+        the ultimate real table.
+
+        Bare-column refs in multi-table FROM mirror Postgres: resolved by
+        searching each underlying table's column list. Ambiguous or
+        missing references are recorded as None.
+        """
+        if not body.fromClause:
+            return {}
+
+        # Collect (alias_or_relname, relname) for each direct source table
+        # in the FROM clause. JoinExpr is flattened.
+        sources = []
+        for f in body.fromClause:
+            if isinstance(f, RangeVar):
+                sources.append(f)
+            elif isinstance(f, JoinExpr):
+                sources.extend(
+                    j for j in _extract_recursive_joins(f) if isinstance(j, RangeVar)
+                )
+
+        # Build alias → relname map for this body.
+        alias_to_relname = {}
+        for rv in sources:
+            alias = rv.alias.aliasname if rv.alias is not None else rv.relname
+            alias_to_relname[alias] = rv.relname
+
+        def resolve(relname, col):
+            """Resolve a (source_relname, source_col) reference to the
+            ultimate (real_table, real_col). Composes through CTE lineage."""
+            if relname in self.cte_column_lineage:
+                return self.cte_column_lineage[relname].get(col)
+            # Real table — pass through.
+            return (relname, col)
+
+        lineage = {}
+        target_list = body.targetList or ()
+
+        for rt in target_list:
+            if not isinstance(rt, ResTarget):
+                continue
+            v = rt.val
+            # Computed expressions (FuncCall, A_Expr, TypeCast, etc.) have
+            # no traceable lineage. If the user named the result via AS,
+            # we still mark the entry with None so downstream callers can
+            # distinguish "computed" from "untrackable bare col".
+            if not isinstance(v, ColumnRef):
+                if rt.name:
+                    lineage[rt.name] = None
+                continue
+
+            fields = v.fields
+            # `*`: expand for all source tables.
+            if len(fields) == 1 and isinstance(fields[0], A_Star):
+                for rv in sources:
+                    cols = self._get_table_columns(rv.relname)
+                    if cols is None:
+                        continue
+                    for c in cols:
+                        resolved = resolve(rv.relname, c)
+                        if c not in lineage and resolved is not None:
+                            lineage[c] = resolved
+                continue
+
+            # `t.*`: expand for table t only.
+            if (len(fields) == 2 and isinstance(fields[0], String)
+                    and isinstance(fields[1], A_Star)):
+                alias = fields[0].sval
+                relname = alias_to_relname.get(alias)
+                if relname is None:
+                    continue
+                cols = self._get_table_columns(relname)
+                if cols is None:
+                    continue
+                for c in cols:
+                    resolved = resolve(relname, c)
+                    if resolved is not None:
+                        lineage[c] = resolved
+                continue
+
+            # `t.col`: resolve via alias map.
+            if (len(fields) == 2 and isinstance(fields[0], String)
+                    and isinstance(fields[1], String)):
+                alias = fields[0].sval
+                col = fields[1].sval
+                relname = alias_to_relname.get(alias)
+                if relname is None:
+                    continue
+                resolved = resolve(relname, col)
+                key = rt.name if rt.name else col
+                if resolved is not None:
+                    lineage[key] = resolved
+                elif rt.name:
+                    lineage[rt.name] = None
+                continue
+
+            # Bare `col`: search each source table's columns. Mirror
+            # Postgres's rules — exactly one match wins; zero or multiple
+            # leaves the entry as None (None means "we can't trace this").
+            if len(fields) == 1 and isinstance(fields[0], String):
+                col = fields[0].sval
+                matches = []
+                for rv in sources:
+                    cols = self._get_table_columns(rv.relname)
+                    if cols is None:
+                        continue
+                    if col in cols:
+                        matches.append(rv.relname)
+                key = rt.name if rt.name else col
+                if len(matches) == 1:
+                    resolved = resolve(matches[0], col)
+                    if resolved is not None:
+                        lineage[key] = resolved
+                # 0 or multiple → no entry; Postgres would have errored
+                # anyway, or downstream KeyError will surface.
+
+        return lineage
 
     def serialize_cache(self):
         def print_value(x):
@@ -1559,6 +1992,7 @@ def _execute_free_text_queries(
     api_version,
     api_key,
     disable_retriever=False,
+    cte_column_lineage=None,
 ):
     # the predicate should only contain an atomic unstructural query
     # or an AND of multiple unstructural query (NOT of an unstructural query is considered to be atmoic)
@@ -1640,6 +2074,30 @@ def _execute_free_text_queries(
                     else:
                         if column_name.split("^")[1] == field_lst[0].fields[0].sval:
                             field = tuple(column_name.split("^"))
+
+        # If the resolved field references a CTE that we materialized,
+        # rewrite to point at the underlying real table so the embedding
+        # server can find the right FAISS index (which is keyed by
+        # real-table name, not CTE name). Built per-CTE during _process_ctes.
+        if cte_column_lineage and len(field) == 2:
+            cte_name, col_name = field
+            lineage_entry = cte_column_lineage.get(cte_name)
+            if lineage_entry is not None:
+                resolved = lineage_entry.get(col_name)
+                if resolved is not None:
+                    field = resolved
+                elif not disable_retriever:
+                    # Known CTE but this column has no lineage — likely a
+                    # computed expression (e.g. LOWER(col) AS x). Without
+                    # FAISS embeddings for it, the retriever can't help.
+                    raise NotImplementedError(
+                        f"answer() targets column {col_name!r} of CTE "
+                        f"{cte_name!r}, but this column has no traceable "
+                        f"lineage to a real table (likely a computed "
+                        f"expression). Rewrite the CTE to project the "
+                        f"underlying column directly, or pass "
+                        f"disable_retriever=True to bypass the retriever."
+                    )
 
         operator = predicate.name[0].sval
         if isinstance(value_clause, tuple):
@@ -1729,6 +2187,7 @@ def _execute_and(
     host="127.0.0.1",
     port="5432",
     disable_retriever=False,
+    cte_column_lineage=None,
     enable_classifier=False,
 ):
     # there should not exist any OR expression inside sql_dnf_predicates
@@ -1792,6 +2251,7 @@ def _execute_and(
             api_version,
             api_key,
             disable_retriever=disable_retriever,
+            cte_column_lineage=cte_column_lineage,
         )
 
     elif isinstance(sql_dnf_predicates, A_Expr) or (
@@ -1844,6 +2304,7 @@ def _execute_and(
                 api_version,
                 api_key,
                 disable_retriever=disable_retriever,
+                cte_column_lineage=cte_column_lineage,
             )
 
 
@@ -1909,6 +2370,7 @@ def _analyze_SelectStmt(
     api_version=None,
     api_key=None,
     disable_retriever=False,
+    cte_column_lineage=None,
     enable_classifier=False,
 ):
     # first, replace all table aliases
@@ -1945,6 +2407,7 @@ def _analyze_SelectStmt(
                 api_version,
                 api_key,
                 disable_retriever=disable_retriever,
+                cte_column_lineage=cte_column_lineage,
                 enable_classifier=enable_classifier,
             )
             res.extend(choice_res)
@@ -1976,6 +2439,7 @@ def _analyze_SelectStmt(
             api_version,
             api_key,
             disable_retriever=disable_retriever,
+            cte_column_lineage=cte_column_lineage,
             enable_classifier=enable_classifier,
         )
 
@@ -2000,6 +2464,7 @@ def _analyze_SelectStmt(
             api_version,
             api_key,
             disable_retriever=disable_retriever,
+            cte_column_lineage=cte_column_lineage,
             enable_classifier=enable_classifier,
         )
     else:

--- a/tests/test_cte_materialization.py
+++ b/tests/test_cte_materialization.py
@@ -1,0 +1,639 @@
+"""Tests for issue #45: CTE support in queries that mix `answer()` with
+WITH clauses.
+
+Unit tests check the AST-level helpers (dependency graph, topological sort,
+reference rewriting, ID-column inference) in isolation.
+
+Integration tests check that the full pipeline handles:
+  - Case 1: outer query has answer(), CTE doesn't
+  - Case 2: CTE body has answer(), outer doesn't
+  - Case 3 (#45 original): CTEs chain together with answer() in some of them
+  - WITH RECURSIVE containing answer() raises NotImplementedError
+  - Plain (no-CTE) queries are unaffected
+
+End-to-end tests run real SUQL queries against the live Postgres `acled` DB
+AND the live embedding server (default http://127.0.0.1:8505). They use real
+questions and exercise the retriever path — no monkey-patching, no fakes.
+"""
+
+import os
+import sys
+import traceback
+
+import requests as _requests
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
+
+from pglast import parse_sql
+from pglast.ast import (
+    A_Star,
+    ColumnRef,
+    CommonTableExpr,
+    RangeVar,
+    ResTarget,
+    SelectStmt,
+    String,
+)
+
+from suql.sql_free_text_support.execute_free_text_sql import _SelectVisitor
+
+
+def _new_visitor(table_w_ids=None):
+    """Construct a bare _SelectVisitor — enough state to call the helpers."""
+    return _SelectVisitor(
+        fts_fields=[],
+        database="acled",
+        embedding_server_address="http://127.0.0.1:0",  # never reached in unit tests
+        select_username="select_user",
+        select_userpswd="select_user",
+        create_username="select_user",
+        create_userpswd="select_user",
+        table_w_ids=table_w_ids if table_w_ids is not None else {"events": "event_id_cnty"},
+        llm_model_name="gpt-4o-mini",
+        max_verify=10,
+    )
+
+
+# ---------- live-stack config (used by integration + e2e checks) --------------
+
+EMBEDDING_SERVER_ADDRESS = os.environ.get(
+    "SUQL_EMBEDDING_SERVER", "http://127.0.0.1:8505"
+)
+# Real question fired against the events.notes free-text column. Chosen to
+# return at least some rows in the ACLED Colombia subset so the end-to-end
+# tests have something to assert on.
+COLOMBIA_QUESTION = "Does this event relate to the Colombian government?"
+
+
+def _embedding_server_reachable():
+    """True if the embedding server at EMBEDDING_SERVER_ADDRESS accepts the
+    real /search payload shape. Used to skip e2e tests cleanly when the server
+    isn't running (e.g., CI without the embedding stack)."""
+    try:
+        r = _requests.post(
+            EMBEDDING_SERVER_ADDRESS + "/search",
+            json={
+                "id_list": [],
+                "field_query_list": [["events", "notes"]],
+                "top": 1,
+                "single_table": True,
+            },
+            timeout=3,
+        )
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+
+# ---------- unit checks -------------------------------------------------------
+
+def check_find_cte_refs_simple():
+    ast = parse_sql("SELECT * FROM base WHERE answer(notes, 'q') = 'Yes'")[0].stmt
+    refs = _SelectVisitor._find_cte_refs(ast, {"base", "other"})
+    assert refs == {"base"}, refs
+
+
+def check_find_cte_refs_ignores_schema_qualified():
+    ast = parse_sql("SELECT * FROM public.base")[0].stmt
+    refs = _SelectVisitor._find_cte_refs(ast, {"base"})
+    assert refs == set(), refs
+
+
+def check_find_cte_refs_in_join():
+    ast = parse_sql(
+        "SELECT * FROM events e JOIN base b ON e.id = b.id"
+    )[0].stmt
+    refs = _SelectVisitor._find_cte_refs(ast, {"base", "other"})
+    assert refs == {"base"}, refs
+
+
+def check_topo_order_respects_deps():
+    # b depends on a; c depends on b. Order must be a, b, c.
+    ctes = [
+        CommonTableExpr(ctename="c", ctequery=parse_sql("SELECT 1")[0].stmt),
+        CommonTableExpr(ctename="a", ctequery=parse_sql("SELECT 1")[0].stmt),
+        CommonTableExpr(ctename="b", ctequery=parse_sql("SELECT 1")[0].stmt),
+    ]
+    deps = {"a": set(), "b": {"a"}, "c": {"b"}}
+    order = _SelectVisitor._topo_order_ctes(ctes, deps)
+    assert order.index("a") < order.index("b") < order.index("c"), order
+
+
+def check_topo_order_detects_cycle():
+    ctes = [
+        CommonTableExpr(ctename="a", ctequery=parse_sql("SELECT 1")[0].stmt),
+        CommonTableExpr(ctename="b", ctequery=parse_sql("SELECT 1")[0].stmt),
+    ]
+    deps = {"a": {"b"}, "b": {"a"}}
+    try:
+        _SelectVisitor._topo_order_ctes(ctes, deps)
+    except ValueError as e:
+        assert "cycle" in str(e).lower(), e
+        return
+    raise AssertionError("expected ValueError for cycle")
+
+
+def check_rewrite_cte_refs_replaces_relname():
+    body = parse_sql("SELECT * FROM base WHERE id > 0")[0].stmt
+    _SelectVisitor._rewrite_cte_refs(body, {"base": "temp_table_abc"})
+    assert body.fromClause[0].relname == "temp_table_abc"
+
+
+def check_rewrite_cte_refs_leaves_unknown_alone():
+    body = parse_sql("SELECT * FROM events e")[0].stmt
+    _SelectVisitor._rewrite_cte_refs(body, {"base": "temp_table_abc"})
+    assert body.fromClause[0].relname == "events"
+
+
+def check_projection_includes_bare_star():
+    body = parse_sql("SELECT * FROM events e")[0].stmt
+    assert _SelectVisitor._projection_includes(body.targetList, "e", "event_id_cnty") is True
+
+
+def check_projection_includes_qualified_star():
+    body = parse_sql("SELECT e.* FROM events e")[0].stmt
+    assert _SelectVisitor._projection_includes(body.targetList, "e", "event_id_cnty") is True
+
+
+def check_projection_includes_explicit_column():
+    body = parse_sql("SELECT e.event_id_cnty FROM events e")[0].stmt
+    assert _SelectVisitor._projection_includes(body.targetList, "e", "event_id_cnty") is True
+
+
+def check_projection_excludes_other_column():
+    body = parse_sql("SELECT e.notes FROM events e")[0].stmt
+    assert _SelectVisitor._projection_includes(body.targetList, "e", "event_id_cnty") is False
+
+
+def check_infer_id_column_single_table():
+    v = _new_visitor()
+    body = parse_sql(
+        "SELECT e.event_id_cnty, e.notes FROM events e"
+    )[0].stmt
+    assert v._infer_cte_id_column(body) == "event_id_cnty"
+
+
+def check_infer_id_column_unknown_underlying():
+    v = _new_visitor(table_w_ids={"foreign_table": "fid"})
+    body = parse_sql("SELECT * FROM events e")[0].stmt
+    assert v._infer_cte_id_column(body) is None
+
+
+def check_infer_id_column_id_not_projected():
+    v = _new_visitor()
+    body = parse_sql("SELECT e.notes FROM events e")[0].stmt
+    assert v._infer_cte_id_column(body) is None
+
+
+def check_infer_id_column_join_with_answer_returns_mangled():
+    # Join + answer() => _execute_structural_sql produces ^-mangled column
+    # names. Inferred ID must match (= 'events^event_id_cnty'), otherwise
+    # the outer's _retrieve_and_verify cannot find the column.
+    v = _new_visitor(table_w_ids={"events": "event_id_cnty", "other": "oid"})
+    body = parse_sql(
+        "SELECT e.* FROM events e JOIN other o ON e.event_id_cnty = o.oid "
+        "WHERE answer(e.notes, 'q') = 'Yes'"
+    )[0].stmt
+    assert v._infer_cte_id_column(body) == "events^event_id_cnty"
+
+
+def check_infer_id_column_join_without_answer_returns_unmangled():
+    # No answer() in the body => CREATE TABLE AS preserves original column
+    # names. No mangling needed.
+    v = _new_visitor(table_w_ids={"events": "event_id_cnty", "other": "oid"})
+    body = parse_sql(
+        "SELECT e.* FROM events e JOIN other o ON e.event_id_cnty = o.oid"
+    )[0].stmt
+    assert v._infer_cte_id_column(body) == "event_id_cnty"
+
+
+# ---------- lineage builder ---------------------------------------------------
+
+def check_lineage_qualified_column():
+    v = _new_visitor()
+    body = parse_sql("SELECT e.notes, e.event_id_cnty FROM events e")[0].stmt
+    lin = v._build_cte_column_lineage(body)
+    assert lin == {
+        "notes": ("events", "notes"),
+        "event_id_cnty": ("events", "event_id_cnty"),
+    }, lin
+
+
+def check_lineage_qualified_with_rename():
+    # `t.col AS new_name` => lineage key is the rename target.
+    v = _new_visitor()
+    body = parse_sql("SELECT e.notes AS body FROM events e")[0].stmt
+    lin = v._build_cte_column_lineage(body)
+    assert lin == {"body": ("events", "notes")}, lin
+
+
+def check_lineage_qualified_star():
+    v = _new_visitor()
+    # Stub the column-list lookup (no DB needed for unit tests).
+    v._table_columns_cache["events"] = ["event_id_cnty", "notes", "country"]
+    body = parse_sql("SELECT e.* FROM events e")[0].stmt
+    lin = v._build_cte_column_lineage(body)
+    assert lin == {
+        "event_id_cnty": ("events", "event_id_cnty"),
+        "notes": ("events", "notes"),
+        "country": ("events", "country"),
+    }, lin
+
+
+def check_lineage_bare_star_single_table():
+    v = _new_visitor()
+    v._table_columns_cache["events"] = ["event_id_cnty", "notes"]
+    body = parse_sql("SELECT * FROM events e")[0].stmt
+    lin = v._build_cte_column_lineage(body)
+    assert lin == {
+        "event_id_cnty": ("events", "event_id_cnty"),
+        "notes": ("events", "notes"),
+    }, lin
+
+
+def check_lineage_bare_col_unambiguous_in_join():
+    # `notes` exists only in `events`, not in `other`. Postgres would accept;
+    # so should our lineage builder, resolving to events.
+    v = _new_visitor(table_w_ids={"events": "event_id_cnty", "other": "oid"})
+    v._table_columns_cache["events"] = ["event_id_cnty", "notes"]
+    v._table_columns_cache["other"] = ["oid", "description"]
+    body = parse_sql(
+        "SELECT notes FROM events e JOIN other o ON e.event_id_cnty = o.oid"
+    )[0].stmt
+    lin = v._build_cte_column_lineage(body)
+    assert lin == {"notes": ("events", "notes")}, lin
+
+
+def check_lineage_bare_col_ambiguous_in_join_is_dropped():
+    # `notes` exists in both — Postgres would reject as ambiguous; we
+    # mirror that by leaving the entry out (no lineage = downstream
+    # KeyError surfaces, which matches Postgres-style behavior).
+    v = _new_visitor(table_w_ids={"events": "event_id_cnty", "other": "oid"})
+    v._table_columns_cache["events"] = ["event_id_cnty", "notes"]
+    v._table_columns_cache["other"] = ["oid", "notes"]
+    body = parse_sql(
+        "SELECT notes FROM events e JOIN other o ON e.event_id_cnty = o.oid"
+    )[0].stmt
+    lin = v._build_cte_column_lineage(body)
+    assert "notes" not in lin, lin
+
+
+def check_lineage_computed_expression_marked_none():
+    # `LOWER(e.notes) AS x` is computed — no FAISS embedding for it.
+    # Record the AS name with None so callers can detect "tried to map but
+    # got nowhere."
+    v = _new_visitor()
+    body = parse_sql("SELECT LOWER(e.notes) AS x FROM events e")[0].stmt
+    lin = v._build_cte_column_lineage(body)
+    assert lin == {"x": None}, lin
+
+
+def check_lineage_chained_cte_composes():
+    # cand references base. cand's lineage for `notes` should compose
+    # through base's lineage all the way back to (events, notes).
+    v = _new_visitor()
+    # Pre-populate base's lineage as if _process_ctes had handled it.
+    v.cte_column_lineage["base"] = {
+        "notes": ("events", "notes"),
+        "event_id_cnty": ("events", "event_id_cnty"),
+    }
+    body = parse_sql("SELECT notes FROM base")[0].stmt
+    lin = v._build_cte_column_lineage(body)
+    assert lin == {"notes": ("events", "notes")}, lin
+
+
+def check_lineage_chained_qualified_through_cte():
+    v = _new_visitor()
+    v.cte_column_lineage["base"] = {
+        "notes": ("events", "notes"),
+        "event_id_cnty": ("events", "event_id_cnty"),
+    }
+    body = parse_sql("SELECT b.notes AS body FROM base b")[0].stmt
+    lin = v._build_cte_column_lineage(body)
+    assert lin == {"body": ("events", "notes")}, lin
+
+
+UNIT_CHECKS = [
+    check_find_cte_refs_simple,
+    check_find_cte_refs_ignores_schema_qualified,
+    check_find_cte_refs_in_join,
+    check_topo_order_respects_deps,
+    check_topo_order_detects_cycle,
+    check_rewrite_cte_refs_replaces_relname,
+    check_rewrite_cte_refs_leaves_unknown_alone,
+    check_projection_includes_bare_star,
+    check_projection_includes_qualified_star,
+    check_projection_includes_explicit_column,
+    check_projection_excludes_other_column,
+    check_infer_id_column_single_table,
+    check_infer_id_column_unknown_underlying,
+    check_infer_id_column_id_not_projected,
+    check_infer_id_column_join_with_answer_returns_mangled,
+    check_infer_id_column_join_without_answer_returns_unmangled,
+    check_lineage_qualified_column,
+    check_lineage_qualified_with_rename,
+    check_lineage_qualified_star,
+    check_lineage_bare_star_single_table,
+    check_lineage_bare_col_unambiguous_in_join,
+    check_lineage_bare_col_ambiguous_in_join_is_dropped,
+    check_lineage_computed_expression_marked_none,
+    check_lineage_chained_cte_composes,
+    check_lineage_chained_qualified_through_cte,
+]
+
+
+# ---------- integration checks (real DB; require acled + select_user) ---------
+
+def _run(sql, table_w_ids=None):
+    from suql.sql_free_text_support.execute_free_text_sql import suql_execute
+    return suql_execute(
+        sql,
+        table_w_ids=table_w_ids if table_w_ids is not None else {"events": "event_id_cnty"},
+        database="acled",
+        select_username="select_user",
+        select_userpswd="select_user",
+        host="127.0.0.1",
+        port="5432",
+        llm_model_name="gpt-4o-mini",
+        disable_retriever=True,
+        disable_try_catch=True,
+        statement_timeout=30000,
+    )
+
+
+def check_case1_outer_answer():
+    # outer has answer(), CTE doesn't. ID column registration is what carries
+    # this case — no materialization needed.
+    sql = (
+        "WITH base AS (SELECT e.event_date, e.notes, e.event_id_cnty "
+        "              FROM events e WHERE e.country = 'Colombia' LIMIT 5) "
+        f"SELECT event_id_cnty FROM base WHERE answer(notes, '{COLOMBIA_QUESTION}') = 'Yes' LIMIT 1;"
+    )
+    _run(sql)
+
+
+def check_case2_cte_answer():
+    # CTE has answer(), outer doesn't.
+    sql = (
+        "WITH cand AS (SELECT * FROM events WHERE country = 'Colombia' "
+        f"              AND answer(notes, '{COLOMBIA_QUESTION}') = 'Yes' LIMIT 5) "
+        "SELECT event_id_cnty FROM cand LIMIT 1;"
+    )
+    _run(sql)
+
+
+def check_issue_45_multi_ref():
+    # Original #45 shape: `base` referenced by two downstream CTEs that have
+    # answer(). Confirms transitive materialization works (base gets
+    # materialized via _materialize_cte_body_directly because its deps need it).
+    sql = (
+        "WITH base AS (SELECT e.event_date, e.notes, e.event_id_cnty "
+        "              FROM events e WHERE e.country = 'Colombia' LIMIT 5), "
+        "     candidate_a AS (SELECT * FROM base "
+        f"                     WHERE answer(notes, 'Does this event involve the Colombian government?') = 'Yes'), "
+        "     candidate_b AS (SELECT * FROM base "
+        f"                     WHERE answer(notes, 'Does this event involve civilians in Colombia?') = 'Yes') "
+        "SELECT (SELECT COUNT(*) FROM candidate_a) AS a_cnt, "
+        "       (SELECT COUNT(*) FROM candidate_b) AS b_cnt;"
+    )
+    _run(sql)
+
+
+def check_with_recursive_with_answer_refused():
+    sql = (
+        "WITH RECURSIVE r AS ("
+        "  SELECT event_id_cnty, notes FROM events WHERE event_id_cnty = 'X' "
+        "  UNION "
+        "  SELECT e.event_id_cnty, e.notes FROM events e "
+        "  JOIN r ON r.event_id_cnty = e.event_id_cnty "
+        f"  WHERE answer(e.notes, '{COLOMBIA_QUESTION}') = 'Yes'"
+        ") SELECT * FROM r;"
+    )
+    try:
+        _run(sql)
+    except NotImplementedError as e:
+        assert "WITH RECURSIVE" in str(e), e
+        return
+    raise AssertionError("expected NotImplementedError")
+
+
+def check_no_cte_regression():
+    # Plain query without WITH still works.
+    sql = (
+        "SELECT event_id_cnty FROM events "
+        f"WHERE country = 'Colombia' AND answer(notes, '{COLOMBIA_QUESTION}') = 'Yes' LIMIT 1;"
+    )
+    _run(sql)
+
+
+INTEGRATION_CHECKS = [
+    check_case1_outer_answer,
+    check_case2_cte_answer,
+    check_issue_45_multi_ref,
+    check_with_recursive_with_answer_refused,
+    check_no_cte_regression,
+]
+
+
+# ---------- end-to-end (exercise full pipeline + verify semantics) ------------
+
+def _suql_e2e(sql, **overrides):
+    """Run a SUQL query end-to-end against the real Postgres + the real
+    embedding server. Uses disable_retriever=False so the retriever path
+    (and thus our lineage tracker) actually fires.
+    """
+    from suql.sql_free_text_support.execute_free_text_sql import suql_execute
+    kwargs = dict(
+        table_w_ids={"events": "event_id_cnty"},
+        database="acled",
+        select_username="select_user",
+        select_userpswd="select_user",
+        host="127.0.0.1",
+        port="5432",
+        embedding_server_address=EMBEDDING_SERVER_ADDRESS,
+        llm_model_name="gpt-4o-mini",
+        disable_retriever=False,
+        disable_try_catch=True,
+        statement_timeout=120000,
+    )
+    kwargs.update(overrides)
+    return suql_execute(sql, **kwargs)
+
+
+def check_lineage_rewrite_via_real_server():
+    """CTE wraps `events` under the name `base`; outer answer() targets
+    `notes`. Without our lineage rewrite, the embedding server would be
+    asked for ('base','notes') — for which there is no FAISS index — and
+    return zero rows. With the rewrite it gets ('events','notes') and
+    returns real candidates.
+
+    We assert by comparing against a flat (no-CTE) query that asks the
+    same question over the same row set. The id-set returned by the CTE
+    shape must be a subset of the flat-query id-set (LLM may answer
+    differently across runs; subset is the strongest stable invariant).
+    """
+    flat_sql = (
+        "SELECT event_id_cnty FROM events "
+        f"WHERE country='Colombia' AND answer(notes, '{COLOMBIA_QUESTION}')='Yes' "
+        "LIMIT 10;"
+    )
+    cte_sql = (
+        "WITH base AS (SELECT * FROM events WHERE country='Colombia') "
+        f"SELECT event_id_cnty FROM base WHERE answer(notes, '{COLOMBIA_QUESTION}')='Yes' "
+        "LIMIT 10;"
+    )
+
+    flat_rows, _, _ = _suql_e2e(flat_sql)
+    cte_rows, _, _ = _suql_e2e(cte_sql)
+
+    flat_ids = {r[0] for r in flat_rows}
+    cte_ids = {r[0] for r in cte_rows}
+
+    # The CTE-wrapped version must actually retrieve candidates from the
+    # embedding server (proves lineage rewrite hit ('events','notes')).
+    assert cte_rows, "CTE-wrapped query returned zero rows — lineage rewrite likely broken"
+    # Both queries select from the same row set with the same question; CTE
+    # ids should be a subset of (or equal to) the flat-query ids modulo LLM
+    # nondeterminism. Strict equality is too brittle; require non-empty
+    # overlap.
+    overlap = cte_ids & flat_ids
+    assert overlap, (
+        f"no overlap between flat and CTE row sets: flat={flat_ids}, cte={cte_ids}"
+    )
+
+
+def check_cte_vs_noncte_row_equivalence():
+    """Same logical query in two shapes — with and without a wrapping CTE.
+    The retrieved id set for the CTE shape must overlap meaningfully with
+    the flat shape. (LLM nondeterminism makes strict equality brittle;
+    overlap is the strongest stable invariant.)
+    """
+    no_cte = (
+        "SELECT event_id_cnty FROM events "
+        f"WHERE country='Colombia' AND answer(notes, '{COLOMBIA_QUESTION}')='Yes' LIMIT 10;"
+    )
+    with_cte = (
+        "WITH colombia AS (SELECT * FROM events WHERE country='Colombia') "
+        f"SELECT event_id_cnty FROM colombia WHERE answer(notes, '{COLOMBIA_QUESTION}')='Yes' LIMIT 10;"
+    )
+
+    rows_no, _, _ = _suql_e2e(no_cte)
+    rows_with, _, _ = _suql_e2e(with_cte)
+    ids_no = {r[0] for r in rows_no}
+    ids_with = {r[0] for r in rows_with}
+    assert ids_with, "CTE-wrapped query returned zero rows"
+    assert ids_no, "flat query returned zero rows"
+    overlap = ids_no & ids_with
+    assert overlap, (
+        f"no overlap between CTE and flat row sets: flat={ids_no}, cte={ids_with}"
+    )
+
+
+def check_computed_expression_in_cte_refused_at_retriever():
+    """An outer answer() targets a column that's a computed expression in
+    the CTE projection. The lineage builder records None for that column,
+    and breakdown_unstructural_query raises a clear NotImplementedError
+    *before* any embedding-server call — verified end-to-end."""
+    sql = (
+        "WITH t AS (SELECT event_id_cnty, LOWER(notes) AS x FROM events "
+        "           WHERE country='Colombia' LIMIT 5) "
+        f"SELECT event_id_cnty FROM t WHERE answer(x, '{COLOMBIA_QUESTION}')='Yes' LIMIT 1;"
+    )
+    try:
+        _suql_e2e(sql)
+    except NotImplementedError as e:
+        assert "lineage" in str(e).lower() or "computed" in str(e).lower(), e
+        return
+    raise AssertionError("expected NotImplementedError for computed-expression CTE column")
+
+
+def check_chained_cte_end_to_end():
+    """Three-CTE chain A -> B -> C, where B has answer(). Verifies that
+    transitive materialization gets A done before B, that B's body sees a
+    real temp table for A, and that C reads B's results. Hits real
+    embedding server + real LLM. The COUNT must come back as a single
+    non-negative integer."""
+    sql = (
+        "WITH a AS (SELECT * FROM events WHERE country='Colombia' LIMIT 5), "
+        f"     b AS (SELECT * FROM a WHERE answer(notes, '{COLOMBIA_QUESTION}')='Yes'), "
+        "     c AS (SELECT event_id_cnty FROM b) "
+        "SELECT COUNT(*) FROM c;"
+    )
+    results, _, _ = _suql_e2e(sql)
+    assert len(results) == 1, results
+    count = results[0][0]
+    assert 0 <= count <= 5, count
+
+
+def check_multi_table_cte_body_end_to_end():
+    """CTE body has a join over (events, a constant dates CTE).
+    Outer answer() targets the events-derived notes column. Lineage must
+    map (joined_cte, notes) → (events, notes) for the retriever to find
+    the correct index. Hits real embedding server + real LLM."""
+    sql = (
+        "WITH dates AS (SELECT DATE '2020-01-01' AS d), "
+        "     ce AS (SELECT e.event_id_cnty, e.notes "
+        "            FROM events e JOIN dates d ON e.event_date >= d.d "
+        "            WHERE e.country='Colombia' LIMIT 5) "
+        f"SELECT event_id_cnty FROM ce WHERE answer(notes, '{COLOMBIA_QUESTION}')='Yes' LIMIT 1;"
+    )
+    _suql_e2e(sql)
+
+
+END_TO_END_CHECKS = [
+    check_lineage_rewrite_via_real_server,
+    check_cte_vs_noncte_row_equivalence,
+    check_computed_expression_in_cte_refused_at_retriever,
+    check_chained_cte_end_to_end,
+    check_multi_table_cte_body_end_to_end,
+]
+
+
+# ---------- runner ------------------------------------------------------------
+
+def main():
+    failures = []
+    print("--- unit ---")
+    for check in UNIT_CHECKS:
+        try:
+            check()
+            print(f"[PASS] {check.__name__}")
+        except Exception:
+            print(f"[FAIL] {check.__name__}")
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    print("\n--- integration (requires acled DB + select_user) ---")
+    for check in INTEGRATION_CHECKS:
+        try:
+            check()
+            print(f"[PASS] {check.__name__}")
+        except Exception:
+            print(f"[FAIL] {check.__name__}")
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    print(f"\n--- end-to-end (hits real DB, embedding server, LLM) ---")
+    if not _embedding_server_reachable():
+        print(f"[SKIP] embedding server at {EMBEDDING_SERVER_ADDRESS} not reachable — "
+              f"skipping {len(END_TO_END_CHECKS)} e2e checks")
+    else:
+        for check in END_TO_END_CHECKS:
+            try:
+                check()
+                print(f"[PASS] {check.__name__}")
+            except Exception:
+                print(f"[FAIL] {check.__name__}")
+                traceback.print_exc()
+                failures.append(check.__name__)
+
+    if failures:
+        print(f"\n{len(failures)} failed: {failures}")
+        sys.exit(1)
+    print("\nall checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #45. Adds full CTE support to the SUQL compiler. CTEs that are referenced by multiple downstream CTEs containing `answer()` / `summary()` previously crashed with `KeyError` on `table_w_ids[<cte_name>]` because the compiler had no CTE awareness — `_retrieve_and_verify` expected `(real_table, col)` for embedding lookup but got `(<cte_name>, col)`. This PR fixes that, and threads the necessary metadata so the embedding server / FAISS index lookups remain correct in CTE-bearing queries.

## Approach: full materialization + column lineage tracking

New `_SelectVisitor._process_ctes` runs before the outer query so the outer (and downstream CTEs) can resolve references through the existing answer()/temp-table machinery. Steps:

1. **Build dependency graph** of CTEs by walking each body for bare `RangeVar` references whose `relname` matches a sibling CTE.
2. **Topological sort** (Kahn's algorithm) with cycle detection.
3. **Compute materialization set**: seed with CTEs that contain `answer()`/`summary()`; expand transitively so every dependency of a materialized CTE is also materialized (otherwise the SUQL pipeline can't resolve references when it runs the body standalone).
4. **Process in topo order**:
   - CTEs with `answer()`/`summary()` go through `visit_SelectStmt` recursively (creates a temp table via the existing answer() pipeline).
   - CTEs without answer() that need materialization for downstream use get a direct `CREATE TABLE temp_X AS <body>` via the new `_materialize_cte_body_directly`.
5. **Rewrite cross-CTE references** (`cte_name` → `temp_X`) so downstream bodies resolve correctly when SUQL runs them standalone.
6. **Build column lineage** per CTE: `{projected_col_name: (underlying_real_table, real_col)}`. Composes transitively through chained CTEs. Consumed by `breakdown_unstructural_query` to rewrite `(cte_name, col)` → `(real_table, real_col)` so the embedding server can find the correct FAISS index (which is keyed by real-table name, not CTE name).
7. **Best-effort ID column inference** per CTE so outer `answer()` queries against it can dedup. Returns `^`-mangled column name when the CTE body uses joins + `answer()` (to match `_execute_structural_sql`'s join-branch naming convention).

## Refusals

Two cases raise a clear `NotImplementedError` rather than silently producing wrong results:

- **`WITH RECURSIVE` containing `answer()`/`summary()`** — recursive CTEs would require LLM calls per recursion step; out of scope. Non-recursive CTEs work; `WITH RECURSIVE` without answer() is passed through to Postgres natively.
- **`answer()` targeting a computed-expression CTE column** (e.g. `WITH t AS (SELECT LOWER(notes) AS x FROM events) SELECT … WHERE answer(x, '…')='Yes'`) **when the retriever is enabled** — no FAISS index can exist for a computed value. The error message recommends rewriting the CTE to project the underlying column, or passing `disable_retriever=True` for that workload.

## Bug C: tmp-table cleanup leak (fixed in same commit)

Pre-existing latent leak in `visit_SelectStmt`: `tmp_table_name` was appended to `self.tmp_tables` BEFORE `CREATE TABLE` actually ran. If `_analyze_SelectStmt` raised mid-flight, the name was in the cleanup list but no table existed, and `drop_tmp_tables()` would try to `DROP` a nonexistent table — printing `Error executing SQL query: table "temp_table_X" does not exist` and continuing. The new `NotImplementedError` for computed-expression refusal is what made this visible. Fix: moved `.append` to after `CREATE TABLE` succeeds.

## Tests — 35 checks in `tests/test_cte_materialization.py`

- **25 unit checks** (no DB needed): `_find_cte_refs`, `_topo_order_ctes` (incl. cycle detection), `_rewrite_cte_refs`, `_projection_includes` for bare/qualified/explicit star, `_infer_cte_id_column` for single-table/join/multi-join with and without answer(), `_build_cte_column_lineage` for qualified column / rename / `t.*` / bare `*` / bare unambiguous / bare ambiguous / computed expr / chained-CTE composition.
- **5 integration checks** (real `acled` Postgres): Case 1 (outer answer, CTE doesn't), Case 2 (CTE has answer, outer doesn't), the original #45 multi-ref repro, WITH RECURSIVE + answer() refusal, no-CTE regression.
- **5 end-to-end checks** (real Postgres + embedding server at `http://127.0.0.1:8505` + real LLM verification via `gpt-4o-mini`): lineage-rewrite visible at retriever, CTE vs flat row-set equivalence, computed-expression refusal end-to-end, chained `A → B → C` with answer() in B, multi-table CTE body with sibling JOIN.

All 35 pass. Output is clean (no swallowed compiler errors thanks to #52 merged in #53).

## Test plan for reviewer

- [ ] `python tests/test_cte_materialization.py` — verifies the 35 checks pass against the local `acled` DB + embedding server + LLM.
- [ ] Run any production CTE query from your workload — should now work where it previously crashed with KeyError.
- [ ] Sanity-check a `WITH RECURSIVE` query without answer() — should pass through to Postgres natively.

## Related

- Depends on / built on top of #52 (merged in #53) — without the `enable_classifier=False` default, the classifier's CTE-scoping bug would pollute test output.
- #44 (star expansion, merged in #49) is also leveraged by CTE bodies that project `t.*`.