### PR TITLE
fix(compiler): support answer() over computed text expressions (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to SUQL are documented in this file. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- **`answer()` over a computed text expression (issue #50).** The text argument
+  of a free-text function no longer has to be a bare column: `answer(COALESCE(a,
+  '') || ' ' || COALESCE(b, ''), '...')`, `answer(lower(notes), '...')` and any
+  other text-typed SQL expression now work, instead of tripping
+  `assert len(field_lst) == 1` in `breakdown_unstructural_query`. The compiler
+  projects the expression in the structural query under an internal
+  `_suql_expr_<hash>` alias (stripped again before results are returned), so
+  Postgres evaluates it once per row and the LLM verifies the expression's own
+  value. Retrieval falls back to the FAISS indexes of the columns the
+  expression reads from — an unindexed column is skipped with a warning, and
+  when nothing is retrievable the compiler verifies every surviving row, or
+  raises if that would exceed 1000 rows (pass `disable_retriever=True` to force
+  it). The text argument and the question are now read positionally, so a
+  string literal as the text argument no longer confuses the parser either.
+- **Table-qualified projections with `answer()`.** `SELECT e.event_id_cnty FROM
+  events e WHERE answer(...)` failed with `missing FROM-clause entry for table
+  "events"`: the FROM clause is swapped for the temp table holding the verified
+  rows, which left qualified references dangling. The temp table now carries
+  the original table name as an alias.
+- `answer()` on a NULL text value is now `False` instead of raising an
+  `AssertionError` inside verification.
+
 ## [1.1.10a3] - 2026-05-13
 
 ### Added

--- a/src/suql/sql_free_text_support/execute_free_text_sql.py
+++ b/src/suql/sql_free_text_support/execute_free_text_sql.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import contextvars
+import hashlib
 import json
 import logging
 import random
@@ -10,7 +11,7 @@ import traceback
 from collections import defaultdict
 from copy import deepcopy
 from functools import lru_cache
-from typing import Dict, List, Union
+from typing import Dict, List, NamedTuple, Union
 from uuid import uuid4
 
 import pglast
@@ -71,6 +72,146 @@ def _if_contains_free_text_fcn(node):
     return visitor.res
 
 
+def _if_free_text_fcn(node):
+    """True if `node` is itself a call to a free text function (`answer`)."""
+    return isinstance(node, FuncCall) and any(
+        i.sval in _SET_FREE_TEXT_FCNS for i in node.funcname if isinstance(i, String)
+    )
+
+
+# Prefix for the synthetic columns under which computed text arguments of
+# `answer()` (e.g. `COALESCE(notes,'') || ' ' || COALESCE(tags,'')`) are
+# projected by the structural query. These are internal to the compiler and are
+# stripped before results reach the user (see issue #50).
+_INTERNAL_EXPR_COLUMN_PREFIX = "_suql_expr_"
+
+
+class _ComputedTextField(NamedTuple):
+    """Identifies the text input of a free text function when that input is a
+    computed SQL expression instead of a bare column reference, e.g.
+    `answer(COALESCE(notes,'') || ' ' || COALESCE(tags,''), '...')`.
+
+    Interchangeable with the usual `(table, column)` field tuple: index 0 is the
+    table the expression is drawn from ("" if it cannot be determined, e.g.
+    joins), and index 1 is the synthetic alias under which the structural query
+    materializes the expression's value. `expr_sql` keeps the original SQL text
+    for prompts and logging, and `source_columns` lists the real (table, column)
+    pairs the expression reads - the only things the retriever can prefilter on.
+    """
+
+    table: str
+    column: str
+    expr_sql: str
+    source_columns: tuple = ()
+
+
+def _computed_text_alias(expr_sql: str):
+    """Deterministic projection alias for a computed text expression. Derived
+    from the expression's SQL text so that the structural query and the
+    verification step independently agree on the same name."""
+    digest = hashlib.md5(expr_sql.encode("utf-8")).hexdigest()[:12]
+    return _INTERNAL_EXPR_COLUMN_PREFIX + digest
+
+
+def _free_text_fcn_args(free_text_clause: FuncCall):
+    """Returns the (text argument node, question string) of a free text function
+    call. The text argument is positional - it may be a bare `ColumnRef` or any
+    computed text expression."""
+    args = free_text_clause.args if free_text_clause.args else ()
+    func_name = ".".join(
+        i.sval for i in free_text_clause.funcname if isinstance(i, String)
+    )
+    if len(args) < 2:
+        raise ValueError(
+            "expects '{}' to be called with a text argument and a question, "
+            "but got: {}".format(func_name, RawStream()(free_text_clause))
+        )
+    query_arg = args[1]
+    if not (isinstance(query_arg, A_Const) and isinstance(query_arg.val, String)):
+        raise ValueError(
+            "expects the question argument of '{}' to be a string literal, "
+            "but got: {}".format(func_name, RawStream()(free_text_clause))
+        )
+    return args[0], query_arg.val.sval
+
+
+class _ExtractComputedTextArgs(Visitor):
+    """Collects the text arguments of free text function calls that are computed
+    SQL expressions rather than bare column references, keyed by the synthetic
+    alias they will be projected under."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.res: Dict[str, object] = {}
+
+    def __call__(self, node):
+        if node is None:
+            return
+        super().__call__(node)
+
+    def visit_FuncCall(self, ancestors, node: FuncCall):
+        if not _if_free_text_fcn(node):
+            return
+        text_arg, _ = _free_text_fcn_args(node)
+        if isinstance(text_arg, ColumnRef):
+            return
+        self.res[_computed_text_alias(RawStream()(text_arg))] = text_arg
+
+
+def _extract_computed_text_args(node):
+    visitor = _ExtractComputedTextArgs()
+    visitor(node)
+    return visitor.res
+
+
+class _ExtractColumnRefs(Visitor):
+    """Collects every `ColumnRef` appearing under a node, in order."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.res = []
+
+    def __call__(self, node):
+        if node is None:
+            return
+        super().__call__(node)
+
+    def visit_ColumnRef(self, ancestors, node: ColumnRef):
+        self.res.append(node)
+
+
+def _extract_column_refs(node):
+    visitor = _ExtractColumnRefs()
+    visitor(node)
+    return visitor.res
+
+
+def _field_display_name(field):
+    """Human-readable name of the text source, used in verification prompts and
+    logging. For computed expressions, the synthetic alias means nothing to an
+    LLM - show the expression instead."""
+    if isinstance(field, _ComputedTextField):
+        return field.expr_sql
+    return field[1]
+
+
+def _drop_internal_columns(results, column_info):
+    """Removes the synthetic computed-expression columns (see
+    `_INTERNAL_EXPR_COLUMN_PREFIX`) from a result set, so that they neither
+    reach the user nor the temporary tables built from these results."""
+    keep = [
+        i
+        for i, column in enumerate(column_info)
+        if not str(column[0]).startswith(_INTERNAL_EXPR_COLUMN_PREFIX)
+    ]
+    if len(keep) == len(column_info):
+        return results, column_info
+    return (
+        [tuple(row[i] for i in keep) for row in results],
+        [column_info[i] for i in keep],
+    )
+
+
 def _extract_all_free_text_fcns(suql):
     node = parse_sql(suql)
     visitor = _ExtractAllFreeTextFncs()
@@ -91,14 +232,13 @@ class _ExtractAllFreeTextFncs(Visitor):
     def visit_FuncCall(self, ancestors, node: pglast.ast.FuncCall):
         for i in node.funcname:
             if i.sval in self._SET_FREE_TEXT_FCNS:
-                query_lst = list(filter(lambda x: isinstance(x, A_Const), node.args))
-                assert len(query_lst) == 1
-                query = query_lst[0].val.sval
+                text_arg, query = _free_text_fcn_args(node)
 
-                field_lst = list(filter(lambda x: isinstance(x, ColumnRef), node.args))
-                assert len(field_lst) == 1
-
-                field = tuple(map(lambda x: x.sval, field_lst[0].fields))
+                if isinstance(text_arg, ColumnRef):
+                    field = tuple(map(lambda x: x.sval, text_arg.fields))
+                else:
+                    # computed text expression (issue #50)
+                    field = (RawStream()(text_arg),)
 
                 self.res.append((field, query))
 
@@ -329,6 +469,11 @@ class _SelectVisitor(Visitor):
                 enable_classifier=self.enable_classifier,
             )
 
+            # computed text expressions given to answer() are projected under
+            # internal aliases (issue #50) - they have served their purpose by
+            # now and must not leak into the temp table or the user's results
+            results, column_info = _drop_internal_columns(results, column_info)
+
             # based on results and column_info, insert a temporary table
             column_create_stmt = ",\n".join(
                 list(map(lambda x: f'"{x[0]}" {x[1]}', column_info))
@@ -380,8 +525,25 @@ class _SelectVisitor(Visitor):
                     )
 
             # finally, modify the existing sql with tmp_table_name
+            # For a single table, the rest of the query may still refer to its
+            # columns table-qualified (`SELECT events.event_id_cnty ...`, or an
+            # alias that _replace_table_aliases turned into the table name).
+            # Alias the temp table back to that name so those references keep
+            # resolving. Joins don't need this - _Replace_Original_Target_Visitor
+            # already rewrote their references to the "table^column" form.
+            original_from = node.fromClause
+            table_alias = (
+                Alias(aliasname=original_from[0].relname)
+                if len(original_from) == 1 and isinstance(original_from[0], RangeVar)
+                else None
+            )
             node.fromClause = (
-                RangeVar(relname=tmp_table_name, inh=True, relpersistence="p"),
+                RangeVar(
+                    relname=tmp_table_name,
+                    inh=True,
+                    relpersistence="p",
+                    alias=table_alias,
+                ),
             )
             node.whereClause = None
         elif self.enable_classifier:
@@ -933,7 +1095,8 @@ def _verify(
         template_file="prompts/verification.prompt",
         prompt_parameter_values={
             "document": document,
-            "field": field[1],  # field is a tuple (table_name, field_name)
+            # field is a tuple (table_name, field_name), or a _ComputedTextField
+            "field": _field_display_name(field),
             "query": query,
             "answer": answer,
         },
@@ -968,6 +1131,10 @@ def _verify_single_res(
         # for a list, verify against each one, if any returns true then return that
         def verify_single_value(single_value, single_column_name):
             res = False
+            # NULL text (empty column, or a computed expression that evaluated
+            # to NULL) can never satisfy the predicate
+            if single_value is None:
+                return False
             # if this is a string, then directly verify:
             if isinstance(single_value, str):
                 res = _verify(
@@ -1031,7 +1198,7 @@ def _verify_single_res(
                     break
 
         else:
-            if not _verify(
+            if doc[1][i] is None or not _verify(
                 doc[1][i],
                 field,
                 query,
@@ -1047,7 +1214,12 @@ def _verify_single_res(
             else:
                 found_stmt.append(
                     "Verified answer({}, '{}') {} {} in table = {} based on document: {}".format(
-                        field[1], query, operator, value, field[0], doc[1][i]
+                        _field_display_name(field),
+                        query,
+                        operator,
+                        value,
+                        field[0],
+                        doc[1][i],
                     )
                 )
     if all_found:
@@ -1107,6 +1279,123 @@ def _parallel_filtering(fcn, source: list, limit, enforce_ordering=False):
     return true_items
 
 
+# Upper bound on how many rows the compiler is willing to send to the LLM when
+# it falls back to brute-force verification on its own (i.e., the user did not
+# ask for `disable_retriever=True`). Verification is one LLM call per row, so a
+# silent fallback on a large table would be ruinous - error out instead.
+_MAX_IMPLICIT_BRUTE_FORCE_ROWS = 1000
+
+
+def _search_embedding_server(
+    embedding_server_address, column, query, id_list, top, single_table
+):
+    """Runs one /search call against a single (table, column) FAISS index.
+    Returns the server's result list, or None if that index is unavailable."""
+    try:
+        response = requests.post(
+            embedding_server_address + "/search",
+            json={
+                "id_list": id_list,
+                "field_query_list": [(list(column), query)],
+                "top": top,
+                "single_table": single_table,
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        logging.warning(
+            "retrieval on column {}.{} failed ({}); the embedding server "
+            "likely does not index it".format(column[0], column[1], e)
+        )
+        return None
+    return response.json()["result"]
+
+
+def _retrieve_candidate_ids(
+    field_query_list, id_list, single_table, top, embedding_server_address
+):
+    """Prefilters rows for predicates whose text input is a computed expression
+    (issue #50). The expression itself has no FAISS index, so each predicate is
+    retrieved on the indexed columns its expression reads from, unioning the
+    hits across those columns. Predicates are ANDed, so the per-predicate id
+    sets are intersected, keeping the first predicate's relevance order.
+
+    Returns None if retrieval was impossible for at least one predicate, in
+    which case the caller has to verify rows without a prefilter.
+    """
+    per_predicate = []
+    for entry in field_query_list:
+        field, query = entry[0], entry[1]
+        source_columns = (
+            field.source_columns
+            if isinstance(field, _ComputedTextField)
+            else (tuple(field),)
+        )
+
+        ordered_ids = []
+        seen = set()
+        retrieved = False
+        for column in source_columns:
+            res = _search_embedding_server(
+                embedding_server_address, column, query, id_list, top, single_table
+            )
+            if res is None:
+                continue
+            retrieved = True
+            for row in res:
+                row_ids = row[0] if isinstance(row[0], list) else [row[0]]
+                for row_id in row_ids:
+                    if row_id not in seen:
+                        seen.add(row_id)
+                        ordered_ids.append(row_id)
+
+        if not retrieved:
+            return None
+        per_predicate.append((ordered_ids, seen))
+
+    if not per_predicate:
+        return None
+    common = set.intersection(*[seen for _, seen in per_predicate])
+    return [row_id for row_id in per_predicate[0][0] if row_id in common]
+
+
+def _read_field_values(
+    field_query_list, existing_results, column_info, id_index, single_table, keep_ids
+):
+    """Builds the `[id, [document per predicate]]` structure the verification
+    step consumes, reading each predicate's text straight off the structural
+    query's rows (rather than from the retriever).
+
+    `keep_ids` is an ordered list of row ids to keep, or None to keep every row.
+    """
+    column_names = [x[0] for x in column_info]
+    field_indices = []
+    for field_entry in field_query_list:
+        field = field_entry[0]
+        if isinstance(field, _ComputedTextField):
+            # computed expressions are projected under their synthetic alias
+            # verbatim, in both single-table and join queries
+            target = field.column
+        else:
+            table_part, col_part = field
+            target = col_part if single_table else f"{table_part}^{col_part}"
+        field_indices.append(column_names.index(target))
+
+    if keep_ids is None:
+        rows = existing_results
+    else:
+        by_id = defaultdict(list)
+        for existing_res in existing_results:
+            by_id[existing_res[id_index]].append(existing_res)
+        rows = [row for row_id in keep_ids for row in by_id[row_id]]
+
+    return [
+        [row[id_index], [row[i] for i in field_indices]]
+        for row in rows
+    ]
+
+
 def _retrieve_and_verify(
     node: SelectStmt,
     field_query_list,
@@ -1133,6 +1422,14 @@ def _retrieve_and_verify(
     # existing_results: existing results to run retrieval on, this is a list of tuples
     # column_info: this is a list of tuples, first element is column name and second is type
     # limit: max number of returned results
+
+    # The retriever is keyed by (table, column) - it has no FAISS index for a
+    # computed text expression like `COALESCE(notes,'') || ' ' || tags`, so
+    # those predicates take a separate retrieval path (issue #50).
+    has_computed_field = any(
+        isinstance(x[0], _ComputedTextField) for x in field_query_list
+    )
+
     if len(node.fromClause) == 1 and isinstance(node.fromClause[0], RangeVar):
         id_field_name = table_w_ids[node.fromClause[0].relname]
         single_table = True
@@ -1177,16 +1474,48 @@ def _retrieve_and_verify(
         # verification on every row that survived the structural prefilter.
         # `field_query_list` carries (table, column) tuples; column_info carries
         # bare column names for single-table queries and "table^column" for joins.
-        column_names = [x[0] for x in column_info]
-        parsed_result = []
-        for existing_res in existing_results:
-            intermediate_result = []
-            for field_entry in field_query_list:
-                table_part, col_part = field_entry[0]
-                target = col_part if single_table else f"{table_part}^{col_part}"
-                field_index = column_names.index(target)
-                intermediate_result.append(existing_res[field_index])
-            parsed_result.append([existing_res[id_index], intermediate_result])
+        parsed_result = _read_field_values(
+            field_query_list,
+            existing_results,
+            column_info,
+            id_index,
+            single_table,
+            keep_ids=None,
+        )
+    elif has_computed_field:
+        # Retrieve on the indexed columns that the computed expressions read
+        # from, but verify against the expression's own value, which the
+        # structural query already materialized for every row (issue #50).
+        candidate_ids = _retrieve_candidate_ids(
+            field_query_list,
+            id_list,
+            single_table,
+            limit * max_verify,
+            embedding_server_address,
+        )
+        if candidate_ids is None:
+            if len(existing_results) > _MAX_IMPLICIT_BRUTE_FORCE_ROWS:
+                raise NotImplementedError(
+                    "answer() is called on a computed text expression that the "
+                    "retriever cannot prefilter on, and {} rows survive the "
+                    "structural filter - verifying them all would mean one LLM "
+                    "call per row. Narrow the query with structural predicates, "
+                    "make answer() read an embedded column directly, or pass "
+                    "disable_retriever=True to run the LLM on every row "
+                    "anyway.".format(len(existing_results))
+                )
+            logging.warning(
+                "no retrievable column backs the computed text expression(s); "
+                "verifying every row that survives the structural filter"
+            )
+        parsed_result = _read_field_values(
+            field_query_list,
+            existing_results,
+            column_info,
+            id_index,
+            single_table,
+            keep_ids=candidate_ids,
+        )
     elif fetch_all:
         # first get all free text fields:
         all_free_text_columns = []
@@ -1939,6 +2268,18 @@ def _execute_structural_sql(
     else:
         node.targetList = (ResTarget(val=ColumnRef(fields=(A_Star(),))),)
 
+    # Free text functions can take a computed text expression instead of a bare
+    # column, e.g. answer(COALESCE(notes,'') || ' ' || COALESCE(tags,''), '...').
+    # Project those expressions under a deterministic alias so that Postgres
+    # evaluates them once per row, and the LLM verification step can read the
+    # resulting string off each row (see issue #50). These columns are internal
+    # and get stripped before results are returned (_drop_internal_columns).
+    computed_text_args = _extract_computed_text_args(original_node.whereClause)
+    node.targetList = tuple(node.targetList) + tuple(
+        ResTarget(name=alias, val=deepcopy(expr))
+        for alias, expr in sorted(computed_text_args.items())
+    )
+
     # reset all limits
     node.limitCount = None
     node.limitOffset = None
@@ -2020,6 +2361,85 @@ def _execute_free_text_queries(
                 raise ValueError()
         return tuple(res)
 
+    def _extract_value_clause(value_clause):
+        if isinstance(value_clause, tuple):
+            return extract_tuple_value(value_clause)
+        elif isinstance(value_clause.val, String):
+            return value_clause.val.sval
+        elif isinstance(value_clause.val, Integer):
+            return value_clause.val.ival
+        else:
+            raise ValueError()
+
+    def resolve_column_ref(column_ref: ColumnRef):
+        """Resolves a `ColumnRef` to a (table, column) tuple, using the FROM
+        clause and the structural query's column names. Returns None for a
+        wildcard (`*` / `t.*`), which names no single column to retrieve on."""
+        if any(isinstance(x, A_Star) for x in column_ref.fields):
+            return None
+        field = tuple(x.sval for x in column_ref.fields if isinstance(x, String))
+        if len(field) > 1:
+            assert len(field) == 2
+            return field
+
+        # we need to find out the associated table for this field
+        if len(node.fromClause) == 1 and isinstance(node.fromClause[0], RangeVar):
+            return (node.fromClause[0].relname, field[0])
+
+        for column_name, _ in column_info:
+            if "^" not in column_name:
+                continue
+            else:
+                if column_name.split("^")[1] == field[0]:
+                    return tuple(column_name.split("^"))
+        return field
+
+    def resolve_cte_lineage(field, strict):
+        """If `field` references a CTE that we materialized, rewrites it to
+        point at the underlying real table so the embedding server can find the
+        right FAISS index (which is keyed by real-table name, not CTE name).
+        Built per-CTE during `_process_ctes`.
+
+        Returns None when the column cannot be traced back to a real table and
+        `strict` is False; raises in that same situation when `strict` is True.
+        """
+        if field is None or not cte_column_lineage or len(field) != 2:
+            return field
+        cte_name, col_name = field
+        lineage_entry = cte_column_lineage.get(cte_name)
+        if lineage_entry is None:
+            return field
+        resolved = lineage_entry.get(col_name)
+        if resolved is not None:
+            return resolved
+        if disable_retriever:
+            return field
+        # Known CTE but this column has no lineage — likely a
+        # computed expression (e.g. LOWER(col) AS x). Without
+        # FAISS embeddings for it, the retriever can't help.
+        if not strict:
+            return None
+        raise NotImplementedError(
+            f"answer() targets column {col_name!r} of CTE "
+            f"{cte_name!r}, but this column has no traceable "
+            f"lineage to a real table (likely a computed "
+            f"expression). Rewrite the CTE to project the "
+            f"underlying column directly, or pass "
+            f"disable_retriever=True to bypass the retriever."
+        )
+
+    def resolve_source_columns(text_arg):
+        """Real (table, column) pairs that a computed text expression draws
+        from. These are what the retriever can prefilter on - the expression
+        itself has no FAISS index."""
+        res = []
+        for column_ref in _extract_column_refs(text_arg):
+            column = resolve_cte_lineage(resolve_column_ref(column_ref), strict=False)
+            if column is None or len(column) != 2 or column in res:
+                continue
+            res.append(column)
+        return tuple(res)
+
     def breakdown_unstructural_query(predicate: A_Expr):
         assert _if_contains_free_text_fcn(
             predicate.lexpr
@@ -2046,70 +2466,36 @@ def _execute_free_text_queries(
         assert isinstance(free_text_clause, FuncCall)
         assert assert_A_Const_Or_Tuple_A_Const(value_clause)
 
-        query_lst = list(
-            filter(lambda x: isinstance(x, A_Const), free_text_clause.args)
-        )
-        assert len(query_lst) == 1
-        query = query_lst[0].val.sval
+        text_arg, query = _free_text_fcn_args(free_text_clause)
 
-        field_lst = list(
-            filter(lambda x: isinstance(x, ColumnRef), free_text_clause.args)
-        )
-        assert len(field_lst) == 1
-
-        field = tuple(map(lambda x: x.sval, field_lst[0].fields))
-        if len(field) > 1:
-            assert len(field) == 2
+        # The text argument can be an arbitrary text-typed expression (issue
+        # #50). Anything other than a bare column has already been projected by
+        # the structural query under a synthetic alias - point the field there.
+        if not isinstance(text_arg, ColumnRef):
+            expr_sql = RawStream()(text_arg)
+            table_name = (
+                node.fromClause[0].relname
+                if len(node.fromClause) == 1
+                and isinstance(node.fromClause[0], RangeVar)
+                else ""
+            )
+            field = _ComputedTextField(
+                table=table_name,
+                column=_computed_text_alias(expr_sql),
+                expr_sql=expr_sql,
+                source_columns=resolve_source_columns(text_arg),
+            )
         else:
-            # we need to find out the associated table for this field
-            if len(node.fromClause) == 1 and isinstance(node.fromClause[0], RangeVar):
-                field = (
-                    node.fromClause[0].relname,
-                    field_lst[0].fields[0].sval,
+            field = resolve_cte_lineage(resolve_column_ref(text_arg), strict=True)
+            if field is None:
+                raise ValueError(
+                    "the text argument of a free text function must name a "
+                    "column or be a text expression, but is a wildcard: "
+                    "{}".format(RawStream()(free_text_clause))
                 )
-            else:
-                for column_name, _ in column_info:
-                    if "^" not in column_name:
-                        continue
-                    else:
-                        if column_name.split("^")[1] == field_lst[0].fields[0].sval:
-                            field = tuple(column_name.split("^"))
-
-        # If the resolved field references a CTE that we materialized,
-        # rewrite to point at the underlying real table so the embedding
-        # server can find the right FAISS index (which is keyed by
-        # real-table name, not CTE name). Built per-CTE during _process_ctes.
-        if cte_column_lineage and len(field) == 2:
-            cte_name, col_name = field
-            lineage_entry = cte_column_lineage.get(cte_name)
-            if lineage_entry is not None:
-                resolved = lineage_entry.get(col_name)
-                if resolved is not None:
-                    field = resolved
-                elif not disable_retriever:
-                    # Known CTE but this column has no lineage — likely a
-                    # computed expression (e.g. LOWER(col) AS x). Without
-                    # FAISS embeddings for it, the retriever can't help.
-                    raise NotImplementedError(
-                        f"answer() targets column {col_name!r} of CTE "
-                        f"{cte_name!r}, but this column has no traceable "
-                        f"lineage to a real table (likely a computed "
-                        f"expression). Rewrite the CTE to project the "
-                        f"underlying column directly, or pass "
-                        f"disable_retriever=True to bypass the retriever."
-                    )
 
         operator = predicate.name[0].sval
-        if isinstance(value_clause, tuple):
-            value = extract_tuple_value(value_clause)
-        elif isinstance(value_clause.val, String):
-            value = value_clause.val.sval
-        elif isinstance(value_clause.val, Integer):
-            value = value_clause.val.ival
-        else:
-            raise ValueError()
-
-        return field, query, operator, value
+        return field, query, operator, _extract_value_clause(value_clause)
 
     # TODO: handle cases with NOT
 
@@ -2317,6 +2703,12 @@ class _FindTableAliasVisitor(Visitor):
         super().__call__(node)
         
     def visit_RangeVar(self, ancestors: Ancestor, node: RangeVar):
+        # Temp tables carry a compatibility alias that visit_SelectStmt adds
+        # after their subtree was already analyzed. Rewriting references to it
+        # here would be wrong (and two temp tables can share the alias name).
+        if node.relname.startswith("temp_table_"):
+            return
+
         if node.alias and isinstance(node.alias, Alias) and node.alias.aliasname:
             self.alias_mapping[node.alias.aliasname] = node.relname
             

--- a/tests/test_computed_text_answer.py
+++ b/tests/test_computed_text_answer.py
@@ -1,0 +1,530 @@
+"""Tests for issue #50: `answer()` over a computed text expression.
+
+Before this, the text argument of `answer()` had to be a bare `ColumnRef` -
+anything computed (`COALESCE(...)`, `||`, `lower(...)`, ...) tripped
+`assert len(field_lst) == 1` in `breakdown_unstructural_query`.
+
+Now the compiler projects the expression under an internal alias in the
+structural query, retrieves candidates using the indexed columns the expression
+reads from, and verifies the expression's own value with the LLM.
+
+Unit tests check the AST-level helpers in isolation.
+
+Integration tests run the full pipeline against the live Postgres `acled` DB and
+the live embedding server (default http://127.0.0.1:8505), with only the LLM
+verification call stubbed out - so the SQL projection, the retriever call and
+the document that would be handed to the LLM are all real.
+"""
+
+import os
+import sys
+import traceback
+
+import requests as _requests
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
+
+from pglast import parse_sql
+from pglast.ast import ColumnRef
+
+import suql.sql_free_text_support.execute_free_text_sql as suql_module
+from suql.sql_free_text_support.execute_free_text_sql import (
+    _INTERNAL_EXPR_COLUMN_PREFIX,
+    _ComputedTextField,
+    _computed_text_alias,
+    _drop_internal_columns,
+    _extract_all_free_text_fcns,
+    _extract_column_refs,
+    _extract_computed_text_args,
+    _field_display_name,
+    _free_text_fcn_args,
+    suql_execute,
+)
+
+EMBEDDING_SERVER_ADDRESS = os.environ.get(
+    "SUQL_EMBEDDING_SERVER", "http://127.0.0.1:8505"
+)
+QUESTION = "Does this event involve the Colombian military?"
+CONCAT_TEXT = "COALESCE(e.notes, '') || ' | tags: ' || COALESCE(e.tags, '')"
+
+
+def _where_clause(sql):
+    return parse_sql(sql)[0].stmt.whereClause
+
+
+def _answer_call(sql):
+    """The `answer(...)` FuncCall of `WHERE answer(...) = 'Yes'`."""
+    return _where_clause(sql).lexpr
+
+
+def _embedding_server_reachable():
+    try:
+        r = _requests.post(
+            EMBEDDING_SERVER_ADDRESS + "/search",
+            json={
+                "id_list": [],
+                "field_query_list": [["events", "notes"]],
+                "top": 1,
+                "single_table": True,
+            },
+            timeout=3,
+        )
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+# ---------- unit checks -------------------------------------------------------
+
+def check_alias_is_deterministic_and_prefixed():
+    a = _computed_text_alias("COALESCE(notes, '') || tags")
+    b = _computed_text_alias("COALESCE(notes, '') || tags")
+    c = _computed_text_alias("COALESCE(notes, '') || source")
+    assert a == b, (a, b)
+    assert a != c, (a, c)
+    assert a.startswith(_INTERNAL_EXPR_COLUMN_PREFIX), a
+    # must be usable as a bare SQL identifier
+    assert a.replace("_", "").isalnum(), a
+
+
+def check_free_text_fcn_args_positional():
+    call = _answer_call("SELECT * FROM events e WHERE answer(e.notes, 'q') = 'Yes'")
+    text_arg, query = _free_text_fcn_args(call)
+    assert isinstance(text_arg, ColumnRef), text_arg
+    assert query == "q", query
+
+
+def check_free_text_fcn_args_computed_text():
+    call = _answer_call(
+        f"SELECT * FROM events e WHERE answer({CONCAT_TEXT}, 'q') = 'Yes'"
+    )
+    text_arg, query = _free_text_fcn_args(call)
+    assert not isinstance(text_arg, ColumnRef), text_arg
+    assert query == "q", query
+
+
+def check_free_text_fcn_args_rejects_missing_question():
+    call = _answer_call("SELECT * FROM events e WHERE answer(e.notes) = 'Yes'")
+    try:
+        _free_text_fcn_args(call)
+    except ValueError as e:
+        assert "question" in str(e), e
+        return
+    raise AssertionError("expected ValueError for a one-argument answer()")
+
+
+def check_free_text_fcn_args_rejects_non_literal_question():
+    call = _answer_call(
+        "SELECT * FROM events e WHERE answer(e.notes, e.tags) = 'Yes'"
+    )
+    try:
+        _free_text_fcn_args(call)
+    except ValueError as e:
+        assert "string literal" in str(e), e
+        return
+    raise AssertionError("expected ValueError for a non-literal question")
+
+
+def check_extract_computed_text_args_finds_expression():
+    where = _where_clause(
+        f"SELECT * FROM events e WHERE answer({CONCAT_TEXT}, 'q') = 'Yes'"
+    )
+    res = _extract_computed_text_args(where)
+    assert len(res) == 1, res
+    alias = list(res)[0]
+    assert alias.startswith(_INTERNAL_EXPR_COLUMN_PREFIX), alias
+
+
+def check_extract_computed_text_args_ignores_bare_column():
+    where = _where_clause("SELECT * FROM events e WHERE answer(e.notes, 'q') = 'Yes'")
+    assert _extract_computed_text_args(where) == {}
+
+
+def check_extract_computed_text_args_dedups_identical_expressions():
+    # the same expression asked two different questions is projected once
+    where = _where_clause(
+        f"SELECT * FROM events e WHERE answer({CONCAT_TEXT}, 'q1') = 'Yes' "
+        f"AND answer({CONCAT_TEXT}, 'q2') = 'Yes'"
+    )
+    assert len(_extract_computed_text_args(where)) == 1
+
+
+def check_extract_computed_text_args_handles_function_call():
+    where = _where_clause(
+        "SELECT * FROM events e WHERE answer(lower(e.notes), 'q') = 'Yes'"
+    )
+    assert len(_extract_computed_text_args(where)) == 1
+
+
+def check_extract_column_refs_finds_underlying_columns():
+    call = _answer_call(
+        f"SELECT * FROM events e WHERE answer({CONCAT_TEXT}, 'q') = 'Yes'"
+    )
+    text_arg, _ = _free_text_fcn_args(call)
+    names = {
+        tuple(f.sval for f in ref.fields) for ref in _extract_column_refs(text_arg)
+    }
+    assert names == {("e", "notes"), ("e", "tags")}, names
+
+
+def check_computed_text_field_is_tuple_compatible():
+    field = _ComputedTextField(
+        table="events",
+        column="_suql_expr_abc",
+        expr_sql="notes || tags",
+        source_columns=(("events", "notes"),),
+    )
+    assert field[0] == "events"
+    assert field[1] == "_suql_expr_abc"
+    # used as a dict key by the verification cache
+    assert {field: 1}[field] == 1
+
+
+def check_field_display_name():
+    field = _ComputedTextField(
+        table="events", column="_suql_expr_abc", expr_sql="notes || tags"
+    )
+    # the LLM is shown the expression, not the meaningless internal alias
+    assert _field_display_name(field) == "notes || tags"
+    assert _field_display_name(("events", "notes")) == "notes"
+
+
+def check_drop_internal_columns():
+    column_info = [
+        ("event_id_cnty", "text"),
+        (_INTERNAL_EXPR_COLUMN_PREFIX + "abc", "text"),
+        ("notes", "text"),
+    ]
+    results = [("a", "computed a", "notes a"), ("b", "computed b", "notes b")]
+    rows, columns = _drop_internal_columns(results, column_info)
+    assert columns == [("event_id_cnty", "text"), ("notes", "text")], columns
+    assert rows == [("a", "notes a"), ("b", "notes b")], rows
+
+
+def check_drop_internal_columns_is_a_noop_without_them():
+    column_info = [("event_id_cnty", "text")]
+    results = [("a",)]
+    rows, columns = _drop_internal_columns(results, column_info)
+    assert rows is results and columns is column_info
+
+
+def check_extract_all_free_text_fcns_handles_computed_text():
+    res = _extract_all_free_text_fcns(
+        f"SELECT * FROM events e WHERE answer({CONCAT_TEXT}, 'q') = 'Yes'"
+    )
+    assert len(res) == 1, res
+    assert res[0][1] == "q", res
+
+
+UNIT_CHECKS = [
+    check_alias_is_deterministic_and_prefixed,
+    check_free_text_fcn_args_positional,
+    check_free_text_fcn_args_computed_text,
+    check_free_text_fcn_args_rejects_missing_question,
+    check_free_text_fcn_args_rejects_non_literal_question,
+    check_extract_computed_text_args_finds_expression,
+    check_extract_computed_text_args_ignores_bare_column,
+    check_extract_computed_text_args_dedups_identical_expressions,
+    check_extract_computed_text_args_handles_function_call,
+    check_extract_column_refs_finds_underlying_columns,
+    check_computed_text_field_is_tuple_compatible,
+    check_field_display_name,
+    check_drop_internal_columns,
+    check_drop_internal_columns_is_a_noop_without_them,
+    check_extract_all_free_text_fcns_handles_computed_text,
+]
+
+
+# ---------- integration checks (real DB + real retriever, stubbed LLM) --------
+
+class _StubbedVerification:
+    """Replaces the LLM verification call with a deterministic keyword match,
+    recording every (document, field) pair it was asked about. Everything else -
+    the structural SQL, the retriever call, the temp table - stays real."""
+
+    def __init__(self, accept="military"):
+        self.accept = accept
+        self.seen = []
+        self._original = None
+
+    def __enter__(self):
+        self._original = suql_module._verify
+
+        def _fake_verify(document, field, query, operator, value, *args, **kwargs):
+            self.seen.append((document, field))
+            return self.accept in (document or "").lower()
+
+        suql_module._verify = _fake_verify
+        return self
+
+    def __exit__(self, *exc):
+        suql_module._verify = self._original
+        return False
+
+    @property
+    def documents(self):
+        return [doc for doc, _ in self.seen]
+
+
+def _run(sql, **overrides):
+    kwargs = dict(
+        table_w_ids={"events": "event_id_cnty"},
+        database="acled",
+        select_username="select_user",
+        select_userpswd="select_user",
+        host="127.0.0.1",
+        port="5432",
+        embedding_server_address=EMBEDDING_SERVER_ADDRESS,
+        llm_model_name="gpt-4o-mini",
+        disable_try_catch=True,
+        statement_timeout=120000,
+    )
+    kwargs.update(overrides)
+    return suql_execute(sql, **kwargs)
+
+
+def check_issue_50_repro():
+    """The shape from the issue: answer() over a concatenation of two columns.
+    Used to raise AssertionError before reaching the database."""
+    sql = (
+        "SELECT e.event_id_cnty FROM events e "
+        "WHERE e.country = 'Colombia' "
+        f"AND answer({CONCAT_TEXT}, '{QUESTION}') = 'Yes' LIMIT 3;"
+    )
+    with _StubbedVerification() as stub:
+        rows, columns, _ = _run(sql)
+
+    assert stub.seen, "no row ever reached verification"
+    assert rows, "query returned no rows"
+    assert columns == ["event_id_cnty"], columns
+
+
+def check_verification_sees_the_computed_text():
+    """The LLM must be handed the value of the whole expression, not one of the
+    columns it reads from."""
+    sql = (
+        "SELECT e.event_id_cnty FROM events e "
+        "WHERE e.country = 'Colombia' "
+        f"AND answer({CONCAT_TEXT}, '{QUESTION}') = 'Yes' LIMIT 3;"
+    )
+    with _StubbedVerification() as stub:
+        _run(sql)
+
+    assert stub.documents, "no document reached verification"
+    for document in stub.documents:
+        assert " | tags: " in document, document[:200]
+    field = stub.seen[0][1]
+    assert isinstance(field, _ComputedTextField), field
+    assert ("events", "notes") in field.source_columns, field
+
+
+def check_retriever_prefilters_on_underlying_column():
+    """`events.notes` is embedded, `events.tags` is not. Retrieval has to fall
+    back to the indexed column rather than verifying all 24k Colombian rows."""
+    sql = (
+        "SELECT e.event_id_cnty FROM events e "
+        "WHERE e.country = 'Colombia' "
+        f"AND answer({CONCAT_TEXT}, '{QUESTION}') = 'Yes' LIMIT 3;"
+    )
+    with _StubbedVerification() as stub:
+        _run(sql)
+
+    colombia_rows = 20000  # the table holds far more Colombian events than this
+    assert len(stub.seen) < colombia_rows, (
+        f"{len(stub.seen)} verification calls - the retriever did not prefilter"
+    )
+
+
+def check_internal_column_does_not_leak_into_select_star():
+    sql = (
+        "SELECT * FROM events e "
+        "WHERE e.country = 'Colombia' "
+        f"AND answer({CONCAT_TEXT}, '{QUESTION}') = 'Yes' LIMIT 1;"
+    )
+    with _StubbedVerification():
+        rows, columns, _ = _run(sql)
+
+    leaked = [c for c in columns if c.startswith(_INTERNAL_EXPR_COLUMN_PREFIX)]
+    assert not leaked, leaked
+    if rows:
+        assert len(rows[0]) == len(columns), (len(rows[0]), len(columns))
+
+
+def check_single_argument_function_expression():
+    sql = (
+        "SELECT e.event_id_cnty FROM events e "
+        "WHERE e.country = 'Colombia' "
+        f"AND answer(lower(e.notes), '{QUESTION}') = 'Yes' LIMIT 2;"
+    )
+    with _StubbedVerification() as stub:
+        rows, _, _ = _run(sql)
+
+    assert stub.documents, "no document reached verification"
+    for document in stub.documents:
+        assert document == document.lower(), document[:200]
+
+
+def check_computed_and_plain_answer_together():
+    """AND of a computed-text predicate and a plain-column one."""
+    sql = (
+        "SELECT e.event_id_cnty FROM events e "
+        "WHERE e.country = 'Colombia' "
+        f"AND answer({CONCAT_TEXT}, '{QUESTION}') = 'Yes' "
+        f"AND answer(e.notes, '{QUESTION}') = 'Yes' LIMIT 2;"
+    )
+    with _StubbedVerification() as stub:
+        _run(sql)
+
+    fields = {type(field) for _, field in stub.seen}
+    assert _ComputedTextField in fields, fields
+    assert tuple in fields, fields
+
+
+def check_unretrievable_expression_over_large_table_is_refused():
+    """An expression with no retrievable column would mean one LLM call per
+    surviving row - the compiler must refuse rather than silently do it."""
+    sql = (
+        "SELECT e.event_id_cnty FROM events e "
+        "WHERE e.country = 'Colombia' "
+        f"AND answer('a' || 'b', '{QUESTION}') = 'Yes' LIMIT 1;"
+    )
+    with _StubbedVerification():
+        try:
+            _run(sql)
+        except NotImplementedError as e:
+            assert "disable_retriever" in str(e), e
+            return
+    raise AssertionError("expected NotImplementedError")
+
+
+def check_plain_column_answer_still_works():
+    """Regression: the bare-column path must be untouched."""
+    sql = (
+        "SELECT e.event_id_cnty FROM events e "
+        "WHERE e.country = 'Colombia' "
+        f"AND answer(e.notes, '{QUESTION}') = 'Yes' LIMIT 3;"
+    )
+    with _StubbedVerification() as stub:
+        rows, columns, _ = _run(sql)
+
+    assert rows, "query returned no rows"
+    assert columns == ["event_id_cnty"], columns
+    assert all(field == ("events", "notes") for _, field in stub.seen)
+
+
+def check_qualified_projection_resolves_against_temp_table():
+    """Independent of the computed-text work, but needed for the issue's own
+    repro: a table-qualified projection must survive the FROM clause being
+    swapped for the temp table holding the verified rows."""
+    sql = (
+        "SELECT e.event_id_cnty, e.notes FROM events e "
+        "WHERE e.country = 'Colombia' "
+        f"AND answer(e.notes, '{QUESTION}') = 'Yes' LIMIT 2;"
+    )
+    with _StubbedVerification():
+        rows, columns, _ = _run(sql)
+
+    assert rows, "query returned no rows"
+    assert columns == ["event_id_cnty", "notes"], columns
+
+
+def check_two_materialized_ctes_plus_outer_answer():
+    """Two CTE bodies over the same table both become temp tables, and the
+    outer query then runs its own answer(). The alias each temp table carries
+    must not be mistaken for a user alias to rewrite."""
+    sql = (
+        "WITH a AS ("
+        "  SELECT e.event_id_cnty, e.notes FROM events e"
+        f"  WHERE e.country = 'Colombia' AND answer(e.notes, '{QUESTION}') = 'Yes'"
+        "  LIMIT 5"
+        "), b AS ("
+        "  SELECT e.event_id_cnty, e.notes FROM events e"
+        "  WHERE e.country = 'Colombia'"
+        "  AND answer(e.notes, 'Does this event involve civilians?') = 'Yes'"
+        "  LIMIT 5"
+        ") "
+        "SELECT event_id_cnty FROM a "
+        f"WHERE answer(notes, '{QUESTION}') = 'Yes' "
+        "AND event_id_cnty NOT IN (SELECT event_id_cnty FROM b) LIMIT 2;"
+    )
+    with _StubbedVerification(accept="colombia"):
+        rows, columns, _ = _run(sql)
+
+    assert columns == ["event_id_cnty"], columns
+
+
+def check_computed_text_in_cte():
+    """The issue's own workaround shape, plus a computed expression on top of
+    the CTE's projection."""
+    sql = (
+        "WITH enriched AS ("
+        "  SELECT e.event_id_cnty, e.notes, e.tags FROM events e"
+        "  WHERE e.country = 'Colombia'"
+        ") "
+        "SELECT event_id_cnty FROM enriched "
+        f"WHERE answer(COALESCE(notes, '') || ' | tags: ' || COALESCE(tags, ''), "
+        f"'{QUESTION}') = 'Yes' LIMIT 2;"
+    )
+    with _StubbedVerification() as stub:
+        rows, columns, _ = _run(sql)
+
+    assert stub.documents, "no document reached verification"
+    for document in stub.documents:
+        assert " | tags: " in document, document[:200]
+    assert columns == ["event_id_cnty"], columns
+
+
+INTEGRATION_CHECKS = [
+    check_issue_50_repro,
+    check_verification_sees_the_computed_text,
+    check_retriever_prefilters_on_underlying_column,
+    check_internal_column_does_not_leak_into_select_star,
+    check_single_argument_function_expression,
+    check_computed_and_plain_answer_together,
+    check_unretrievable_expression_over_large_table_is_refused,
+    check_plain_column_answer_still_works,
+    check_qualified_projection_resolves_against_temp_table,
+    check_two_materialized_ctes_plus_outer_answer,
+    check_computed_text_in_cte,
+]
+
+
+# ---------- runner ------------------------------------------------------------
+
+def main():
+    failures = []
+    print("--- unit ---")
+    for check in UNIT_CHECKS:
+        try:
+            check()
+            print(f"[PASS] {check.__name__}")
+        except Exception:
+            print(f"[FAIL] {check.__name__}")
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    print("\n--- integration (real acled DB + embedding server, stubbed LLM) ---")
+    if not _embedding_server_reachable():
+        print(
+            f"[SKIP] embedding server at {EMBEDDING_SERVER_ADDRESS} not reachable — "
+            f"skipping {len(INTEGRATION_CHECKS)} integration checks"
+        )
+    else:
+        for check in INTEGRATION_CHECKS:
+            try:
+                check()
+                print(f"[PASS] {check.__name__}")
+            except Exception:
+                print(f"[FAIL] {check.__name__}")
+                traceback.print_exc()
+                failures.append(check.__name__)
+
+    if failures:
+        print(f"\n{len(failures)} failed: {failures}")
+        sys.exit(1)
+    print("\nall checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #50.

## Problem

`breakdown_unstructural_query` filtered `answer()`'s args for `ColumnRef` nodes and asserted exactly one was found, so the text argument had to be a bare column. Anything wrapped or composed — `COALESCE(notes,'') || ' ' || COALESCE(tags,'')`, `lower(notes)`, `substring(notes,1,200)` — died on `assert len(field_lst) == 1` before reaching the database (or, with the default handler, silently returned `[]` via `_suql_error_log.txt`).

## Approach

Walking through the issue's repro against the 1.6M-row `events` table:

```sql
SELECT e.event_id_cnty FROM events e
WHERE e.country = 'Colombia'
  AND answer(COALESCE(e.notes,'') || ' | tags: ' || COALESCE(e.tags,''),
             'Does this event involve the Colombian military?') = 'Yes'
LIMIT 3;
```

1. **Projection.** Computed text arguments found in the WHERE clause are appended to the structural query's target list under a deterministic `"_suql_expr_" + md5(expr_sql)[:12]` alias — derived from the expression's SQL text so the projection step and the verification step agree on the name without passing state:

   ```sql
   SELECT *, (COALESCE(events.notes, '') || ' | tags: ') || COALESCE(events.tags, '')
          AS _suql_expr_28bcbb0384cf
   FROM events WHERE events.country = 'Colombia'
   ```

   Postgres evaluates it once per row.

2. **Field resolution.** The text argument and question are now read positionally (`args[0]`, `args[1]`). A non-`ColumnRef` argument becomes a `_ComputedTextField` — a `NamedTuple` that still indexes as the old `(table, column)` tuple, so id lookups, verification-cache keys and logging needed no changes — carrying the expression SQL and the real columns it reads.

3. **Retrieval.** There is no FAISS index for an expression, and building one at query time would mean embedding the whole column set per distinct expression. Instead each predicate is retrieved on the indexed columns its expression reads from (union across those columns, intersect across ANDed predicates); the candidate rows are then verified on the expression's own value read off the projected column. Here: `events.tags` is not indexed → skipped with a warning; `events.notes` → 55 candidates → 55 LLM calls instead of 24,054. A column the server does not index is skipped; when nothing is retrievable at all the compiler verifies every surviving row, but raises rather than silently firing more than 1000 LLM calls (`disable_retriever=True` forces it).

4. **Cleanup.** The internal columns are stripped in `visit_SelectStmt` before the temp table is created, so they leak into neither the temp table nor `SELECT *` results.

The issue's exact repro now returns in ~17s with 15 verification calls.

## Adjacent fixes

Both were needed for the issue's own repro to run end to end:

- `SELECT e.event_id_cnty FROM events e WHERE answer(...)` failed with `missing FROM-clause entry for table "events"` — swapping the FROM clause for the temp table left table-qualified projections dangling. This reproduces on `main` with a plain `answer(e.notes, ...)` too, so it is independent of #50. The temp table now carries the original table name as an alias, and `_FindTableAliasVisitor` skips temp tables so two materialized CTEs cannot collide on that alias.
- `answer()` on a NULL text value is `False` instead of raising an `AssertionError` inside verification.

## Relation to #51

#51 diagnoses the same root cause and recursively collects `ColumnRef`s, unblocking single-column wrappers and turning the multi-column case into a clear `ValueError`; its author noted per-row evaluation of computed text was left as a possible follow-up. This is that follow-up, so the two overlap by construction. One difference worth calling out: collapsing a wrapper to its underlying column means `answer(substring(notes,1,200), ...)` is verified against the entire `notes` field, which silently answers a different question than the one written — here the expression itself is evaluated and verified. The explicit wildcard guard in this PR is taken from #51.

## Tests

`tests/test_computed_text_answer.py` — 15 unit checks on the AST helpers, 11 integration checks running the full pipeline against the live `acled` Postgres DB and the live embedding server. All 26 pass, as do `tests/test_cte_materialization.py` and `tests/test_star_expansion.py`.

Caveat: this box has no working LLM credentials, so the integration checks stub the `_verify` call (recording the documents the LLM would have received). The structural SQL, the retriever calls, the temp tables and the document selection are all real, but no test here exercised a live model response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)