### PR TITLE
fix(compiler): verify answer() comparisons outside the WHERE clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to SUQL are documented in this file. Format loosely follows
 ## [Unreleased]
 
 ### Fixed
+- **`answer()` comparisons outside the WHERE clause.**
+  `CASE WHEN answer(notes, q) = 'Yes' THEN 1 ELSE 0 END` in a SELECT list
+  returned 0 for rows the model had answered correctly, with no error — silently
+  under-counting aggregates. Only `node.whereClause` was ever compiled, so a
+  comparison in the projection was handed to Postgres, which ran the raw
+  plpython3u UDF (whose prompt is open-ended: "Answer a question based on the
+  following text") and byte-compared its free-form prose against the literal.
+  `Yes. A nuclear power station is part of energy infrastructure.` is not
+  `'Yes'`. It also varied run to run, because `prompt_continuation` forces
+  `temperature=1` for the gpt-5 family regardless of the caller's request.
+  The compiler now recognises `answer(...) <op> <literal>` in the projection,
+  `HAVING`, `GROUP BY` and `ORDER BY`, verifies each one per row through the
+  same path a WHERE predicate takes, and materializes the result as a synthetic
+  boolean column. A bare `SELECT *` alongside such a predicate is expanded to
+  the explicit column list so the synthetic column doesn't leak. Uses that want
+  the model's prose (`SELECT answer(notes, 'which city?')`), comparisons against
+  a non-literal, and calls wrapped in another function (`lower(answer(...))`)
+  are left for Postgres as before; an aggregate in the text argument raises
+  `NotImplementedError` rather than silently collapsing to one row.
+
 - **`answer()` over a computed text expression (issue #50).** The text argument
   of a free-text function no longer has to be a bare column: `answer(COALESCE(a,
   '') || ' ' || COALESCE(b, ''), '...')`, `answer(lower(notes), '...')` and any
@@ -27,6 +47,20 @@ All notable changes to SUQL are documented in this file. Format loosely follows
   the original table name as an alias.
 - `answer()` on a NULL text value is now `False` instead of raising an
   `AssertionError` inside verification.
+
+### Changed
+- **Verification LLM calls are explicitly pooled.** Both the WHERE-side filter
+  and the new projection-side path run their verifications through a thread pool
+  sized by `max_verification_workers` (new `suql_execute(...)` parameter,
+  default 32, overridable process-wide with `SUQL_MAX_VERIFICATION_WORKERS`).
+  Previously `_parallel_filtering` constructed an unconfigured
+  `ThreadPoolExecutor`, whose size is `min(32, cpu_count + 4)` — a function of
+  the local core count, when the real ceiling is the LLM provider's rate limit.
+  A projection predicate cannot prune, so it is verified on every output row;
+  the calls are all mutually independent and go into one flat pool rather than
+  being nested per row. Where the query's `LIMIT` cannot be changed by anything
+  downstream (no `GROUP BY`/`HAVING`/`ORDER BY`/`DISTINCT`), it is pushed down
+  ahead of verification, which bounds the number of LLM calls.
 
 ## [1.1.10a3] - 2026-05-13
 

--- a/src/suql/sql_free_text_support/execute_free_text_sql.py
+++ b/src/suql/sql_free_text_support/execute_free_text_sql.py
@@ -3,12 +3,14 @@ import contextvars
 import hashlib
 import json
 import logging
+import os
 import random
 import re
 import string
 import time
 import traceback
 from collections import defaultdict
+from contextlib import contextmanager
 from copy import deepcopy
 from functools import lru_cache
 from typing import Dict, List, NamedTuple, Union
@@ -22,7 +24,7 @@ from pglast.ast import *
 from pglast.enums.parsenodes import A_Expr_Kind
 from pglast.enums.primnodes import BoolExprType, CoercionForm
 from pglast.stream import RawStream
-from pglast.visitors import Ancestor, Visitor
+from pglast.visitors import Ancestor, Skip, Visitor
 from psycopg2 import Error as psyconpg2Error
 from sympy import Symbol, symbols
 from sympy.logic.boolalg import And, Not, Or, to_dnf
@@ -57,6 +59,10 @@ class _FreeTextFcnVisitor(Visitor):
         self.res = False
 
     def __call__(self, node):
+        # absent clauses (a missing WHERE, the empty side of a unary operator)
+        # contain no free text functions
+        if node is None:
+            return
         super().__call__(node)
 
     def visit_FuncCall(self, ancestors, node: pglast.ast.FuncCall):
@@ -212,6 +218,310 @@ def _drop_internal_columns(results, column_info):
     )
 
 
+# Prefix for the synthetic boolean columns that hold the verified value of a
+# free text comparison appearing outside the WHERE clause (see
+# `_verify_projection_predicates`). Unlike `_INTERNAL_EXPR_COLUMN_PREFIX` these
+# columns are *referenced* by the rewritten query, so they do live in the temp
+# table; `*` is expanded explicitly so they don't leak into the user's results.
+_INTERNAL_PRED_COLUMN_PREFIX = "_suql_pred_"
+
+# Aggregates may not appear in the text argument of a free text function that
+# the compiler evaluates: the compiler reads that argument off the structural
+# query one value per *input* row, before any grouping has happened.
+_KNOWN_AGGREGATE_FCNS = frozenset(
+    [
+        "array_agg",
+        "avg",
+        "bit_and",
+        "bit_or",
+        "bool_and",
+        "bool_or",
+        "count",
+        "every",
+        "json_agg",
+        "json_object_agg",
+        "jsonb_agg",
+        "jsonb_object_agg",
+        "max",
+        "min",
+        "stddev",
+        "stddev_pop",
+        "stddev_samp",
+        "string_agg",
+        "sum",
+        "var_pop",
+        "var_samp",
+        "variance",
+    ]
+)
+
+
+class _ContainsAggregate(Visitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.res = False
+
+    def __call__(self, node):
+        if node is None:
+            return
+        super().__call__(node)
+
+    def visit_FuncCall(self, ancestors, node: FuncCall):
+        if node.agg_star or node.agg_distinct or node.agg_order or node.agg_filter:
+            self.res = True
+            return
+        name = ".".join(i.sval for i in node.funcname if isinstance(i, String))
+        if name.rsplit(".", 1)[-1].lower() in _KNOWN_AGGREGATE_FCNS:
+            self.res = True
+
+
+def _contains_aggregate(node):
+    visitor = _ContainsAggregate()
+    visitor(node)
+    return visitor.res
+
+
+def _projection_predicate_alias(predicate_sql: str):
+    """Deterministic column name for a verified free text comparison. Derived
+    from the comparison's SQL text so the same comparison written twice (e.g. in
+    both the projection and ORDER BY) is verified once."""
+    digest = hashlib.md5(predicate_sql.encode("utf-8")).hexdigest()[:12]
+    return _INTERNAL_PRED_COLUMN_PREFIX + digest
+
+
+def _if_projection_predicate(node):
+    """True if `node` is an `answer(...) <op> <literal>` comparison.
+
+    Outside the WHERE clause such a comparison is currently handed to Postgres
+    verbatim, which runs the raw `answer` UDF and string-compares its free-form
+    prose against the literal - so `CASE WHEN answer(notes, q) = 'Yes'` is
+    almost always false even when the model says yes. These are exactly the
+    shapes that can instead be routed through the same verification path a WHERE
+    predicate takes.
+    """
+    if not isinstance(node, A_Expr) or node.kind != A_Expr_Kind.AEXPR_OP:
+        return False
+    if len(node.name) != 1 or not isinstance(node.name[0], String):
+        return False
+
+    lexpr_is_free_text = _if_contains_free_text_fcn(node.lexpr)
+    rexpr_is_free_text = _if_contains_free_text_fcn(node.rexpr)
+    if lexpr_is_free_text == rexpr_is_free_text:
+        # free text on both sides, or on neither - nothing to verify
+        return False
+
+    free_text_clause = node.lexpr if lexpr_is_free_text else node.rexpr
+    value_clause = node.rexpr if lexpr_is_free_text else node.lexpr
+
+    # `lower(answer(...)) = 'yes'` and friends wrap the call in a normalizing
+    # function. The free text call has to be the operand itself for the rewrite
+    # to stay type-correct, since the replacement is a boolean.
+    if not _if_free_text_fcn(free_text_clause):
+        return False
+    args = free_text_clause.args if free_text_clause.args else ()
+    if len(args) < 2:
+        return False
+    if not (isinstance(args[1], A_Const) and isinstance(args[1].val, String)):
+        return False
+
+    # the compared-against value has to be a literal - it is what gets shown to
+    # the verification prompt as the candidate answer
+    return isinstance(value_clause, A_Const) and isinstance(
+        value_clause.val, (String, Integer)
+    )
+
+
+class _ProjectionPredicateVisitor(Visitor):
+    """Collects `answer(...) <op> <literal>` comparisons, and (when `replace` is
+    set) swaps each one for a reference to the synthetic boolean column the
+    compiler materializes for it."""
+
+    def __init__(self, replace=False) -> None:
+        super().__init__()
+        self.replace = replace
+        self.res: Dict[str, tuple] = {}
+
+    def __call__(self, node):
+        if node is None:
+            return
+        return super().__call__(node)
+
+    def visit_SelectStmt(self, ancestors, node: SelectStmt):
+        # A nested SelectStmt (e.g. a scalar subquery in the target list) owns
+        # its own projection; the outer visitor reaches it separately.
+        if node is not self.root:
+            return Skip
+
+    def visit_A_Expr(self, ancestors, node: A_Expr):
+        if not _if_projection_predicate(node):
+            return
+
+        lexpr_is_free_text = _if_contains_free_text_fcn(node.lexpr)
+        free_text_clause = node.lexpr if lexpr_is_free_text else node.rexpr
+        value_clause = node.rexpr if lexpr_is_free_text else node.lexpr
+
+        text_arg, query = _free_text_fcn_args(free_text_clause)
+        if _contains_aggregate(text_arg):
+            raise NotImplementedError(
+                "the text argument of a free text function outside the WHERE "
+                "clause is evaluated once per input row, so it cannot contain "
+                "an aggregate: {}".format(RawStream()(free_text_clause))
+            )
+
+        value = (
+            value_clause.val.sval
+            if isinstance(value_clause.val, String)
+            else value_clause.val.ival
+        )
+        alias = _projection_predicate_alias(RawStream()(node))
+        self.res[alias] = (text_arg, query, node.name[0].sval, value)
+
+        if self.replace:
+            return ColumnRef(fields=(String(sval=alias),))
+
+
+@contextmanager
+def _only_projection_clauses(node: SelectStmt):
+    """Hides the parts of a SelectStmt that the compiler handles elsewhere, so a
+    visitor sees only the projection, HAVING, GROUP BY and ORDER BY.
+
+    The WHERE clause has its own (retrieval-backed) pipeline; CTE bodies are
+    materialized by `_process_ctes`; FROM-clause subqueries are separate
+    SelectStmts that the outer visitor reaches on its own.
+    """
+    saved = (node.whereClause, node.withClause, node.fromClause)
+    node.whereClause = None
+    node.withClause = None
+    node.fromClause = None
+    try:
+        yield
+    finally:
+        node.whereClause, node.withClause, node.fromClause = saved
+
+
+def _extract_projection_predicates(node: SelectStmt, replace=False):
+    """Free text comparisons living outside the WHERE clause, keyed by the
+    synthetic boolean column each will be materialized under."""
+    visitor = _ProjectionPredicateVisitor(replace=replace)
+    with _only_projection_clauses(node):
+        visitor(node)
+    return visitor.res
+
+
+def _expand_star_targets(node: SelectStmt, column_info):
+    """Replaces a bare `*` in the target list with the explicit column list.
+
+    Needed once the compiler appends synthetic boolean columns to the temp
+    table: `SELECT *` against that table would otherwise hand the user the
+    compiler's internal columns.
+    """
+    names = [
+        x[0]
+        for x in column_info
+        if not str(x[0]).startswith(_INTERNAL_PRED_COLUMN_PREFIX)
+    ]
+    expanded = []
+    changed = False
+    for target in node.targetList or ():
+        if (
+            isinstance(target, ResTarget)
+            and isinstance(target.val, ColumnRef)
+            and len(target.val.fields) == 1
+            and isinstance(target.val.fields[0], A_Star)
+        ):
+            changed = True
+            expanded.extend(
+                ResTarget(val=ColumnRef(fields=(String(sval=name),))) for name in names
+            )
+        else:
+            expanded.append(target)
+    if changed:
+        node.targetList = tuple(expanded)
+
+
+def _if_limit_pushdown_safe(node: SelectStmt):
+    """Whether the query's LIMIT can be applied while fetching the rows that
+    projection predicates will be verified against.
+
+    A projection predicate filters nothing, so the rows the query outputs are
+    already determined by the structural part - unless something downstream can
+    reorder or regroup them first.
+
+    An OFFSET is excluded because the rewritten query runs against the temp
+    table and would apply the same OFFSET a second time, skipping past rows that
+    were already skipped once.
+    """
+    return (
+        node.limitCount is not None
+        and node.limitOffset is None
+        and not node.groupClause
+        and not node.havingClause
+        and not node.sortClause
+        and not node.distinctClause
+    )
+
+
+def _extract_compiler_evaluated_computed_text_args(node: SelectStmt):
+    """Computed text arguments of free text functions in every clause the
+    compiler evaluates itself - the WHERE clause plus, since these comparisons
+    are now verified rather than executed, the projection / HAVING / GROUP BY /
+    ORDER BY."""
+    res = dict(_extract_computed_text_args(node.whereClause))
+    for clause in (
+        node.targetList,
+        node.havingClause,
+        node.groupClause,
+        node.sortClause,
+    ):
+        if clause:
+            res.update(_extract_computed_text_args(clause))
+    return res
+
+
+# Number of verification calls kept in flight. These are HTTP round trips to an
+# LLM, so the useful number is a function of the provider's rate limits, not of
+# the local core count (which is what an unconfigured ThreadPoolExecutor uses).
+_DEFAULT_MAX_VERIFICATION_WORKERS = 32
+
+
+def _resolve_max_workers(max_workers=None):
+    if max_workers is not None:
+        return max(1, int(max_workers))
+    from_env = os.environ.get("SUQL_MAX_VERIFICATION_WORKERS")
+    if from_env:
+        try:
+            return max(1, int(from_env))
+        except ValueError:
+            logging.warning(
+                "ignoring non-integer SUQL_MAX_VERIFICATION_WORKERS=%r", from_env
+            )
+    return _DEFAULT_MAX_VERIFICATION_WORKERS
+
+
+def _parallel_map(fcn, items, max_workers=None):
+    """Runs `fcn` over `items` concurrently, preserving input order.
+
+    Like `_parallel_filtering` this is an I/O-bound fan-out (each call waits on
+    an LLM HTTP response), and it copies the calling context into each worker so
+    the per-query cost tracker stays visible. Unlike `_parallel_filtering` there
+    is no early exit and results are keyed by position, so duplicate items are
+    handled correctly.
+    """
+    if not items:
+        return []
+    results = [None] * len(items)
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=_resolve_max_workers(max_workers)
+    ) as executor:
+        futures = {
+            executor.submit(contextvars.copy_context().run, fcn, item): index
+            for index, item in enumerate(items)
+        }
+        for future in concurrent.futures.as_completed(futures):
+            results[futures[future]] = future.result()
+    return results
+
+
 def _extract_all_free_text_fcns(suql):
     node = parse_sql(suql)
     visitor = _ExtractAllFreeTextFncs()
@@ -359,9 +669,12 @@ class _SelectVisitor(Visitor):
         port="5432",
         disable_retriever=False,
         enable_classifier=False,
+        max_verification_workers=None,
     ) -> None:
         super().__init__()
         self.tmp_tables = []
+        # concurrency cap for verification LLM calls (see _resolve_max_workers)
+        self.max_verification_workers = max_verification_workers
         # this cache is to store classifier results for sturctured fields (e.g. cuisines in restaurants)
         self.cache = defaultdict(dict)
         self.fts_fields = fts_fields
@@ -432,47 +745,99 @@ class _SelectVisitor(Visitor):
             else:
                 self._process_ctes(node)
 
-        if not node.whereClause:
+        # `answer(...) = 'Yes'` outside the WHERE clause (in the projection,
+        # HAVING or ORDER BY) is verified by the compiler too, rather than being
+        # left for Postgres to run as the raw UDF and string-compare.
+        # Detect it up front so a query with no WHERE clause at all still gets
+        # compiled.
+        has_projection_predicates = bool(_extract_projection_predicates(node))
+
+        if not node.whereClause and not has_projection_predicates:
             return
 
         # First, understand whether this involves subquery. If it does, then starts with that first and builds upwards
         # If that subquery in turn involves other subqueries, then recursive calls take care of it
-        subquery_visitor = _IfInvovlesSubquery()
-        subquery_visitor(node)
-        sublinks = subquery_visitor.return_top_level_sublinks()
-        for sublink in sublinks:
-            self.visit_SelectStmt(None, sublink)
+        if node.whereClause:
+            subquery_visitor = _IfInvovlesSubquery()
+            subquery_visitor(node)
+            sublinks = subquery_visitor.return_top_level_sublinks()
+            for sublink in sublinks:
+                self.visit_SelectStmt(None, sublink)
 
         freeTextFcnVisitor = _FreeTextFcnVisitor()
         freeTextFcnVisitor(node.whereClause)
 
-        if freeTextFcnVisitor.res:
+        if freeTextFcnVisitor.res or has_projection_predicates:
             tmp_table_name = "temp_table_{}".format(_generate_random_string())
 
-            # main entry point for SUQL compiler optimization
-            results, column_info = _analyze_SelectStmt(
-                node,
-                self.database,
-                self.cache,
-                self.fts_fields,
-                self.embedding_server_address,
-                self.select_username,
-                self.select_userpswd,
-                self.table_w_ids,
-                self.llm_model_name,
-                self.max_verify,
-                self.api_base,
-                self.api_version,
-                self.api_key,
-                disable_retriever=self.disable_retriever,
-                cte_column_lineage=self.cte_column_lineage,
-                enable_classifier=self.enable_classifier,
-            )
+            if freeTextFcnVisitor.res:
+                # main entry point for SUQL compiler optimization
+                results, column_info = _analyze_SelectStmt(
+                    node,
+                    self.database,
+                    self.cache,
+                    self.fts_fields,
+                    self.embedding_server_address,
+                    self.select_username,
+                    self.select_userpswd,
+                    self.table_w_ids,
+                    self.llm_model_name,
+                    self.max_verify,
+                    self.api_base,
+                    self.api_version,
+                    self.api_key,
+                    disable_retriever=self.disable_retriever,
+                    cte_column_lineage=self.cte_column_lineage,
+                    enable_classifier=self.enable_classifier,
+                )
+            else:
+                # Nothing to retrieve on - the WHERE clause is purely
+                # structural. Run it as-is to get the rows the query will
+                # output, so the projection predicates can be verified per row.
+                results, column_info = _execute_structural_sql(
+                    node,
+                    self.database,
+                    node.whereClause,
+                    self.cache,
+                    self.fts_fields,
+                    self.select_username,
+                    self.select_userpswd,
+                    self.llm_model_name,
+                    self.api_base,
+                    self.api_version,
+                    self.api_key,
+                    self.host,
+                    self.port,
+                    enable_classifier=self.enable_classifier,
+                    preserve_limit=_if_limit_pushdown_safe(node),
+                )
+
+            if has_projection_predicates:
+                # Re-extract now that _execute_structural_sql has had its chance
+                # to rewrite join column references, and replace each comparison
+                # with the boolean column it is about to be materialized under.
+                projection_predicates = _extract_projection_predicates(
+                    node, replace=True
+                )
+                results, column_info = _verify_projection_predicates(
+                    node,
+                    projection_predicates,
+                    results,
+                    column_info,
+                    self.llm_model_name,
+                    self.api_base,
+                    self.api_version,
+                    self.api_key,
+                    max_workers=self.max_verification_workers,
+                )
 
             # computed text expressions given to answer() are projected under
             # internal aliases (issue #50) - they have served their purpose by
             # now and must not leak into the temp table or the user's results
             results, column_info = _drop_internal_columns(results, column_info)
+
+            if has_projection_predicates:
+                _expand_star_targets(node, column_info)
 
             # based on results and column_info, insert a temporary table
             column_create_stmt = ",\n".join(
@@ -1230,7 +1595,9 @@ def _verify_single_res(
     return all_found
 
 
-def _parallel_filtering(fcn, source: list, limit, enforce_ordering=False):
+def _parallel_filtering(
+    fcn, source: list, limit, enforce_ordering=False, max_workers=None
+):
     true_count = 0
     true_items = set()
 
@@ -1238,7 +1605,9 @@ def _parallel_filtering(fcn, source: list, limit, enforce_ordering=False):
     # which indicates whether an item has been verified
     ordered_results = {i: None for i in range(len(source))}
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=_resolve_max_workers(max_workers)
+    ) as executor:
         futures = {
             executor.submit(contextvars.copy_context().run, fcn, item): item
             for item in source
@@ -1277,6 +1646,147 @@ def _parallel_filtering(fcn, source: list, limit, enforce_ordering=False):
         return res
 
     return true_items
+
+
+def _resolve_projection_text_source(text_arg, node: SelectStmt, single_table, column_names):
+    """Where in the structural query's rows the text argument of a projection
+    predicate can be read from. Returns `(field, column_index)`, where `field`
+    is the usual `(table, column)` tuple or a `_ComputedTextField`."""
+    if isinstance(text_arg, ColumnRef):
+        parts = tuple(x.sval for x in text_arg.fields if isinstance(x, String))
+        if len(parts) != len(text_arg.fields):
+            raise ValueError(
+                "the text argument of a free text function must name a column "
+                "or be a text expression, but is a wildcard: {}".format(
+                    RawStream()(text_arg)
+                )
+            )
+        if single_table:
+            table = node.fromClause[0].relname
+            column = parts[-1]
+            target = column
+        elif len(parts) == 2:
+            table, column = parts
+            target = "{}^{}".format(table, column)
+        else:
+            # Either a join whose column refs _Replace_Original_Target_Visitor
+            # already flattened to "table^column", or a FROM shape that projects
+            # the column under its own name (e.g. a subquery).
+            target = parts[0]
+            if target not in column_names:
+                matches = [c for c in column_names if c.endswith("^" + target)]
+                if len(matches) != 1:
+                    raise ValueError(
+                        "cannot tell which table the text argument {} belongs "
+                        "to; qualify it with a table name".format(target)
+                    )
+                target = matches[0]
+            table, _, column = target.partition("^")
+            if not column:
+                table, column = "", target
+        field = (table, column)
+    else:
+        if not single_table:
+            raise NotImplementedError(
+                "a computed text expression given to answer() outside the WHERE "
+                "clause is only supported for single-table queries; got: "
+                "{}".format(RawStream()(text_arg))
+            )
+        expr_sql = RawStream()(text_arg)
+        target = _computed_text_alias(expr_sql)
+        field = _ComputedTextField(
+            table=node.fromClause[0].relname,
+            column=target,
+            expr_sql=expr_sql,
+        )
+
+    if target not in column_names:
+        raise ValueError(
+            "the structural query did not project {}, needed to verify "
+            "answer({}, ...)".format(target, RawStream()(text_arg))
+        )
+    return field, column_names.index(target)
+
+
+def _verify_projection_predicates(
+    node: SelectStmt,
+    projection_predicates,
+    results,
+    column_info,
+    llm_model_name,
+    api_base=None,
+    api_version=None,
+    api_key=None,
+    max_workers=None,
+):
+    """Evaluates free text comparisons that sit outside the WHERE clause, and
+    appends one synthetic boolean column per comparison to the structural
+    results.
+
+    A WHERE predicate gets to prune, so it can be answered from the top-k the
+    retriever returns. A projection cannot: the query has to emit a value for
+    every row it outputs, and a row the retriever happens to miss would silently
+    become a false negative in the user's aggregate. So there is no retrieval
+    step here - every surviving row is verified.
+
+    That makes this rows x predicates LLM calls, all mutually independent, which
+    is the easy case for concurrency: they go into one flat pool rather than
+    being nested per row (`_verify_single_res` short-circuits on the first false
+    predicate, which is right for a filter and wrong here, since every
+    predicate's value is needed regardless).
+    """
+    single_table = len(node.fromClause) == 1 and isinstance(
+        node.fromClause[0], RangeVar
+    )
+    column_names = [x[0] for x in column_info]
+
+    plan = []
+    for alias, (text_arg, query, operator, value) in sorted(
+        projection_predicates.items()
+    ):
+        field, column_index = _resolve_projection_text_source(
+            text_arg, node, single_table, column_names
+        )
+        plan.append((alias, column_index, field, query, operator, value))
+
+    tasks = [(row, entry) for row in results for entry in plan]
+
+    def verify_one(task):
+        row, (_, column_index, field, query, operator, value) = task
+        document = row[column_index]
+        # NULL text can never satisfy the predicate
+        if document is None:
+            return False
+        if not isinstance(document, str):
+            document = str(document)
+        return _verify(
+            document,
+            field,
+            query,
+            operator,
+            value,
+            llm_model_name,
+            api_base,
+            api_version,
+            api_key,
+        )
+
+    start_time = time.time()
+    verdicts = _parallel_map(verify_one, tasks, max_workers=max_workers)
+    logging.info(
+        "verified %d projection predicate value(s) over %d row(s) in %.2fs",
+        len(tasks),
+        len(results),
+        time.time() - start_time,
+    )
+
+    width = len(plan)
+    new_results = [
+        tuple(row) + tuple(verdicts[i * width : (i + 1) * width])
+        for i, row in enumerate(results)
+    ]
+    new_column_info = list(column_info) + [(entry[0], "boolean") for entry in plan]
+    return new_results, new_column_info
 
 
 # Upper bound on how many rows the compiler is willing to send to the LLM when
@@ -2155,8 +2665,13 @@ def _execute_structural_sql(
     host="127.0.0.1",
     port="5432",
     enable_classifier=False,
+    preserve_limit=False,
 ):
     _ = RawStream()(original_node)  # RawStream takes care of some issue, to investigate
+    # Collect these before the join branch below rewrites `t.col` references in
+    # the projection into the flat "t^col" form: the structural query has to
+    # evaluate the expression against the real tables, using the original names.
+    computed_text_args = _extract_compiler_evaluated_computed_text_args(original_node)
     node = deepcopy(original_node)
     # change projection to include everything
     # there are a couple of cases here
@@ -2274,15 +2789,18 @@ def _execute_structural_sql(
     # evaluates them once per row, and the LLM verification step can read the
     # resulting string off each row (see issue #50). These columns are internal
     # and get stripped before results are returned (_drop_internal_columns).
-    computed_text_args = _extract_computed_text_args(original_node.whereClause)
     node.targetList = tuple(node.targetList) + tuple(
         ResTarget(name=alias, val=deepcopy(expr))
         for alias, expr in sorted(computed_text_args.items())
     )
 
-    # reset all limits
-    node.limitCount = None
-    node.limitOffset = None
+    # reset all limits. `preserve_limit` is set when the caller only needs the
+    # rows the final query will actually output and nothing downstream can
+    # change which rows those are - a projection predicate filters nothing, so
+    # the LIMIT can be pushed down and bound the number of LLM calls.
+    if not preserve_limit:
+        node.limitCount = None
+        node.limitOffset = None
     # change predicates
     node.whereClause = predicate
     # reset other unecessary clauses
@@ -3042,6 +3560,7 @@ def suql_execute(
     debug_log=None,
     disable_retriever=False,
     enable_classifier=False,
+    max_verification_workers=None,
 ):
     """
     Main entry point to the SUQL Python-based compiler.
@@ -3104,6 +3623,11 @@ def suql_execute(
         column's distinct values. Useful for natural-language queries against enum-like columns.
         Defaults to False because the current implementation walks into CTE bodies / subqueries
         and emits spurious probe SQLs there (see issue #52). Set to True to opt in.
+
+    `max_verification_workers` (int, optional): How many verification LLM calls to keep in
+        flight. These are I/O-bound HTTP round trips, so the useful value tracks the provider's
+        rate limits rather than the local core count. Defaults to 32, overridable process-wide
+        with the `SUQL_MAX_VERIFICATION_WORKERS` environment variable.
 
     # Returns:
     `results` (List[[*]]): A list of returned database results. Each inner list stores a row of returned result.
@@ -3198,6 +3722,7 @@ def suql_execute(
             statement_timeout=statement_timeout,
             disable_retriever=disable_retriever,
             enable_classifier=enable_classifier,
+            max_verification_workers=max_verification_workers,
         )
     finally:
         _query_tracker.reset(token)
@@ -3261,6 +3786,7 @@ def _suql_execute_single(
     statement_timeout=30000,
     disable_retriever=False,
     enable_classifier=False,
+    max_verification_workers=None,
 ):
     results = []
     column_names = []
@@ -3285,6 +3811,7 @@ def _suql_execute_single(
             port=port,
             disable_retriever=disable_retriever,
             enable_classifier=enable_classifier,
+            max_verification_workers=max_verification_workers,
         )
         root = parse_sql(suql)
         visitor(root)

--- a/tests/test_projection_answer.py
+++ b/tests/test_projection_answer.py
@@ -1,0 +1,579 @@
+"""Tests for `answer()` comparisons outside the WHERE clause.
+
+`WHERE answer(notes, q) = 'Yes'` is compiled: the comparison goes to the
+verification prompt, which asks the LLM whether 'Yes' is a correct answer to
+`q` for that document. The same comparison in the SELECT list was not compiled
+at all - Postgres ran the raw plpython3u UDF, whose prompt is open-ended
+("Answer a question based on the following text"), and then string-compared its
+free-form prose against the literal. `Yes. The Zaporizhzhia Nuclear Power
+Station is part of energy infrastructure.` != `'Yes'`, so
+`CASE WHEN answer(...) = 'Yes' THEN 1 ELSE 0 END` returned 0 for rows the model
+had answered correctly, silently under-counting aggregates. Because
+`prompt_continuation` forces `temperature=1` for the gpt-5 family, the prose
+also varied run to run.
+
+The compiler now recognises `answer(...) <op> <literal>` in the projection,
+HAVING, GROUP BY and ORDER BY, verifies it per row through the same path a WHERE
+predicate takes, and materializes the result as a synthetic boolean column.
+
+Unit tests check the AST-level helpers in isolation.
+
+Integration tests run the full pipeline against the live Postgres `acled` DB,
+with only the LLM verification call stubbed out - so the structural SQL, the
+temp table, the rewritten query and the documents that would be handed to the
+LLM are all real.
+"""
+
+import os
+import sys
+import threading
+import time
+import traceback
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
+
+from pglast import parse_sql
+from pglast.stream import RawStream
+
+import suql.sql_free_text_support.execute_free_text_sql as suql_module
+from suql.sql_free_text_support.execute_free_text_sql import (
+    _INTERNAL_PRED_COLUMN_PREFIX,
+    _contains_aggregate,
+    _expand_star_targets,
+    _extract_projection_predicates,
+    _if_limit_pushdown_safe,
+    _if_projection_predicate,
+    _parallel_map,
+    _projection_predicate_alias,
+    _resolve_max_workers,
+    suql_execute,
+)
+
+QUESTION = "Is this an attack on energy infrastructure?"
+
+# Hand-labelled rows from the acled `events` table: three attacks on energy
+# infrastructure and three that are not. The stub below accepts on the keyword
+# "power station" / "pipeline", matching the first three.
+POSITIVE_IDS = ["UKR73236", "UKR69217", "UKR88237"]
+NEGATIVE_IDS = ["UKR127789", "UKR73096"]
+ALL_IDS = POSITIVE_IDS + NEGATIVE_IDS
+ID_LITERALS = ", ".join("'{}'".format(i) for i in ALL_IDS)
+
+
+def _stmt(sql):
+    return parse_sql(sql)[0].stmt
+
+
+def _first_target_expr(sql):
+    return _stmt(sql).targetList[0].val
+
+
+# ---------- unit checks -------------------------------------------------------
+
+def check_detects_bare_boolean_projection():
+    expr = _first_target_expr(
+        "SELECT answer(notes, '{}') = 'Yes' FROM events".format(QUESTION)
+    )
+    assert _if_projection_predicate(expr)
+
+
+def check_detects_case_when_and_aggregate_wrappers():
+    for sql in (
+        "SELECT CASE WHEN answer(notes, 'q') = 'Yes' THEN 1 ELSE 0 END FROM events",
+        "SELECT SUM(CASE WHEN answer(notes, 'q') = 'Yes' THEN 1 ELSE 0 END) FROM events",
+        "SELECT COUNT(*) FILTER (WHERE answer(notes, 'q') = 'Yes') FROM events",
+        "SELECT a FROM events GROUP BY a HAVING bool_or(answer(notes, 'q') = 'Yes')",
+        "SELECT a FROM events ORDER BY answer(notes, 'q') = 'Yes' DESC",
+    ):
+        assert len(_extract_projection_predicates(_stmt(sql))) == 1, sql
+
+
+def check_ignores_non_predicate_uses():
+    """A projection that wants the model's prose, or a comparison the
+    verification prompt cannot represent, must be left for Postgres."""
+    for sql in (
+        # the prose is the point
+        "SELECT answer(notes, 'which city?') FROM events",
+        # the WHERE pipeline owns this one
+        "SELECT event_id_cnty FROM events WHERE answer(notes, 'q') = 'Yes'",
+        # RHS is not a literal, so there is no candidate answer to verify
+        "SELECT answer(notes, 'q') = other_col FROM events",
+        # the call is wrapped, so replacing it with a boolean would not typecheck
+        "SELECT lower(answer(notes, 'q')) = 'yes' FROM events",
+        # not a free text function at all
+        "SELECT string_agg(notes, ' ') = 'x' FROM events",
+        # a nested SelectStmt owns its own projection
+        "SELECT (SELECT answer(notes, 'q') = 'Yes' FROM events LIMIT 1) FROM events",
+    ):
+        assert not _extract_projection_predicates(_stmt(sql)), sql
+
+
+def check_identical_comparisons_share_one_column():
+    """The same comparison written twice must be verified once."""
+    sql = (
+        "SELECT answer(notes, 'q') = 'Yes' AS a, "
+        "CASE WHEN answer(notes, 'q') = 'Yes' THEN 1 END AS b FROM events"
+    )
+    preds = _extract_projection_predicates(_stmt(sql))
+    assert len(preds) == 1, preds
+    alias = next(iter(preds))
+    assert alias.startswith(_INTERNAL_PRED_COLUMN_PREFIX), alias
+
+
+def check_alias_is_deterministic():
+    a = _projection_predicate_alias("answer(notes, 'q') = 'Yes'")
+    b = _projection_predicate_alias("answer(notes, 'q') = 'Yes'")
+    c = _projection_predicate_alias("answer(notes, 'q') = 'No'")
+    assert a == b and a != c
+
+
+def check_extraction_does_not_mutate_unless_asked():
+    node = _stmt("SELECT CASE WHEN answer(notes,'q')='Yes' THEN 1 END FROM events")
+    before = RawStream()(node)
+    _extract_projection_predicates(node)
+    assert RawStream()(node) == before
+
+
+def check_replacement_removes_the_udf_call():
+    node = _stmt(
+        "SELECT SUM(CASE WHEN answer(notes,'q')='Yes' THEN 1 ELSE 0 END) "
+        "FROM events WHERE country = 'Ukraine'"
+    )
+    preds = _extract_projection_predicates(node, replace=True)
+    out = RawStream()(node)
+    assert "answer(" not in out.lower(), out
+    assert all(alias in out for alias in preds), out
+    # the WHERE clause is untouched - it has its own pipeline
+    assert "country = 'Ukraine'" in out, out
+
+
+def check_aggregate_text_argument_is_refused():
+    node = _stmt(
+        "SELECT a FROM events GROUP BY a "
+        "HAVING answer(string_agg(notes, ' '), 'q') = 'Yes'"
+    )
+    try:
+        _extract_projection_predicates(node)
+    except NotImplementedError:
+        return
+    raise AssertionError("expected NotImplementedError")
+
+
+def check_contains_aggregate():
+    assert _contains_aggregate(_first_target_expr("SELECT sum(x) FROM t"))
+    assert _contains_aggregate(_first_target_expr("SELECT count(*) FROM t"))
+    assert _contains_aggregate(_first_target_expr("SELECT string_agg(a, ',') FROM t"))
+    assert not _contains_aggregate(_first_target_expr("SELECT lower(a) FROM t"))
+    assert not _contains_aggregate(_first_target_expr("SELECT COALESCE(a, '') FROM t"))
+
+
+def check_limit_pushdown_safety():
+    """A projection predicate filters nothing, so a LIMIT can be applied before
+    verification - unless something downstream reorders or regroups first."""
+    cases = [
+        ("SELECT a FROM t LIMIT 5", True),
+        ("SELECT a FROM t", False),
+        ("SELECT a FROM t ORDER BY a LIMIT 5", False),
+        ("SELECT a FROM t GROUP BY a LIMIT 5", False),
+        ("SELECT DISTINCT a FROM t LIMIT 5", False),
+        # the rewritten query would apply the OFFSET a second time
+        ("SELECT a FROM t LIMIT 5 OFFSET 10", False),
+    ]
+    for sql, want in cases:
+        assert _if_limit_pushdown_safe(_stmt(sql)) == want, sql
+
+
+def check_star_is_expanded_so_internals_do_not_leak():
+    node = _stmt("SELECT *, answer(notes,'q')='Yes' AS f FROM events")
+    _extract_projection_predicates(node, replace=True)
+    _expand_star_targets(
+        node,
+        [("event_id_cnty", "text"), ("notes", "text"), ("_suql_pred_dead", "boolean")],
+    )
+    out = RawStream()(node)
+    assert "*" not in out, out
+    assert "event_id_cnty" in out and "notes" in out, out
+    assert out.count(_INTERNAL_PRED_COLUMN_PREFIX) == 1, out
+
+
+def check_max_workers_resolution():
+    assert _resolve_max_workers(8) == 8
+    assert _resolve_max_workers() == 32
+    os.environ["SUQL_MAX_VERIFICATION_WORKERS"] = "7"
+    try:
+        assert _resolve_max_workers() == 7
+        assert _resolve_max_workers(3) == 3, "explicit argument wins over env"
+    finally:
+        os.environ.pop("SUQL_MAX_VERIFICATION_WORKERS")
+
+
+def check_parallel_map_preserves_order_with_duplicates():
+    got = _parallel_map(lambda x: x * 2, [3, 1, 3, 2, 3], max_workers=4)
+    assert got == [6, 2, 6, 4, 6], got
+    assert _parallel_map(lambda x: x, []) == []
+
+
+UNIT_CHECKS = [
+    check_detects_bare_boolean_projection,
+    check_detects_case_when_and_aggregate_wrappers,
+    check_ignores_non_predicate_uses,
+    check_identical_comparisons_share_one_column,
+    check_alias_is_deterministic,
+    check_extraction_does_not_mutate_unless_asked,
+    check_replacement_removes_the_udf_call,
+    check_aggregate_text_argument_is_refused,
+    check_contains_aggregate,
+    check_limit_pushdown_safety,
+    check_star_is_expanded_so_internals_do_not_leak,
+    check_max_workers_resolution,
+    check_parallel_map_preserves_order_with_duplicates,
+]
+
+
+# ---------- integration -------------------------------------------------------
+
+class _StubbedVerification:
+    """Replaces the LLM verification call with a deterministic keyword match,
+    recording the concurrency it was driven at. Everything else - the structural
+    SQL, the temp table, the rewritten query - stays real."""
+
+    def __init__(self, accept=("power station", "pipeline"), delay=0.0):
+        self.accept = accept
+        self.delay = delay
+        self.seen = []
+        self.max_inflight = 0
+        self._inflight = 0
+        self._lock = threading.Lock()
+        self._original = None
+
+    def __enter__(self):
+        self._original = suql_module._verify
+        # the memo cache would hide repeated calls from this stub
+        suql_module._verified_res = {}
+
+        def _fake_verify(document, field, query, operator, value, *args, **kwargs):
+            with self._lock:
+                self.seen.append((document, field, query, operator, value))
+                self._inflight += 1
+                self.max_inflight = max(self.max_inflight, self._inflight)
+            if self.delay:
+                time.sleep(self.delay)
+            with self._lock:
+                self._inflight -= 1
+            text = (document or "").lower()
+            return any(k in text for k in self.accept)
+
+        suql_module._verify = _fake_verify
+        return self
+
+    def __exit__(self, *exc):
+        suql_module._verify = self._original
+        return False
+
+
+def _run(sql, **overrides):
+    kwargs = dict(
+        table_w_ids={"events": "event_id_cnty"},
+        database="acled",
+        select_username="select_user",
+        select_userpswd="select_user",
+        host="127.0.0.1",
+        port="5432",
+        embedding_server_address=os.environ.get(
+            "SUQL_EMBEDDING_SERVER", "http://127.0.0.1:8505"
+        ),
+        llm_model_name="gpt-4o-mini",
+        disable_try_catch=True,
+        statement_timeout=300000,
+    )
+    kwargs.update(overrides)
+    return suql_execute(sql, **kwargs)
+
+
+def check_reported_repro():
+    """The reported shape. Every row used to come back 0."""
+    sql = (
+        "SELECT event_id_cnty, "
+        "CASE WHEN answer(notes, '{}') = 'Yes' THEN 1 ELSE 0 END AS flag "
+        "FROM events WHERE event_id_cnty IN ({}) ORDER BY event_id_cnty"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification() as stub:
+        rows, columns, _ = _run(sql)
+
+    assert columns == ["event_id_cnty", "flag"], columns
+    got = dict(rows)
+    assert len(got) == len(ALL_IDS), got
+    for i in POSITIVE_IDS:
+        assert got[i] == 1, (i, got)
+    for i in NEGATIVE_IDS:
+        assert got[i] == 0, (i, got)
+    assert len(stub.seen) == len(ALL_IDS), stub.seen
+
+
+def check_verification_sees_the_question_and_the_literal():
+    """The comparison is what gets verified, not just the text: the question and
+    the compared-against value both have to reach the prompt."""
+    sql = (
+        "SELECT answer(notes, '{}') = 'Yes' AS f FROM events "
+        "WHERE event_id_cnty IN ({})"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification() as stub:
+        _run(sql)
+
+    assert stub.seen, "nothing reached verification"
+    for _, field, query, operator, value in stub.seen:
+        assert query == QUESTION, query
+        assert operator == "=", operator
+        assert value == "Yes", value
+        assert field == ("events", "notes"), field
+
+
+def check_aggregate_is_not_undercounted():
+    sql = (
+        "SELECT SUM(CASE WHEN answer(notes, '{}') = 'Yes' THEN 1 ELSE 0 END) AS n "
+        "FROM events WHERE event_id_cnty IN ({})"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert rows and rows[0][0] == len(POSITIVE_IDS), rows
+
+
+def check_projection_is_boolean_not_prose():
+    sql = (
+        "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f FROM events "
+        "WHERE event_id_cnty IN ({})"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert rows and all(isinstance(r[1], bool) for r in rows), rows
+
+
+def check_having_and_order_by():
+    with _StubbedVerification():
+        rows, _, _ = _run(
+            "SELECT country, COUNT(*) AS n FROM events WHERE event_id_cnty IN ({}) "
+            "GROUP BY country HAVING bool_or(answer(notes, '{}') = 'Yes')".format(
+                ID_LITERALS, QUESTION
+            )
+        )
+    assert len(rows) == 1 and rows[0][1] == len(ALL_IDS), rows
+
+    with _StubbedVerification():
+        rows, _, _ = _run(
+            "SELECT event_id_cnty FROM events WHERE event_id_cnty IN ({}) "
+            "ORDER BY answer(notes, '{}') = 'Yes' DESC, event_id_cnty".format(
+                ID_LITERALS, QUESTION
+            )
+        )
+    assert set(r[0] for r in rows[: len(POSITIVE_IDS)]) == set(POSITIVE_IDS), rows
+
+
+def check_internal_column_does_not_leak_into_select_star():
+    sql = (
+        "SELECT *, answer(notes, '{}') = 'Yes' AS f FROM events "
+        "WHERE event_id_cnty IN ({})"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        _, columns, _ = _run(sql)
+    assert not [c for c in columns if str(c).startswith("_suql_")], columns
+    assert "f" in columns, columns
+
+
+def check_two_questions_in_one_query():
+    """rows x predicates, all independent - both columns must be filled in."""
+    sql = (
+        "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS energy, "
+        "answer(notes, 'Did this happen in Ukraine?') = 'Yes' AS ukraine "
+        "FROM events WHERE event_id_cnty IN ({}) ORDER BY event_id_cnty"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification() as stub:
+        rows, columns, _ = _run(sql)
+    assert columns == ["event_id_cnty", "energy", "ukraine"], columns
+    assert len(stub.seen) == 2 * len(ALL_IDS), len(stub.seen)
+    questions = set(q for _, _, q, _, _ in stub.seen)
+    assert len(questions) == 2, questions
+
+
+def check_limit_is_pushed_down_on_an_unfiltered_query():
+    """Without pushdown this would verify every row of a 1.6M-row table."""
+    sql = "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f FROM events LIMIT 3".format(
+        QUESTION
+    )
+    with _StubbedVerification() as stub:
+        rows, _, _ = _run(sql)
+    assert len(rows) == 3, len(rows)
+    assert len(stub.seen) == 3, len(stub.seen)
+
+
+def check_limit_with_offset_still_returns_rows():
+    """The LIMIT may only be pushed down when the rewritten query re-applying it
+    is a no-op; with an OFFSET it is not."""
+    sql = (
+        "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f FROM events "
+        "WHERE country = 'Ukraine' AND year = 2022 LIMIT 3 OFFSET 5"
+    ).format(QUESTION)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert len(rows) == 3, len(rows)
+
+
+def check_column_projected_under_its_own_name_resolves():
+    """A FROM shape that is neither a single RangeVar nor a join still projects
+    the text column under its own name."""
+    sql = (
+        "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f "
+        "FROM (SELECT event_id_cnty, notes FROM events WHERE event_id_cnty IN ({})) sub"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    got = dict(rows)
+    assert len(got) == len(ALL_IDS), got
+    for i in POSITIVE_IDS:
+        assert got[i] is True, (i, got)
+    for i in NEGATIVE_IDS:
+        assert got[i] is False, (i, got)
+
+
+def check_computed_text_expression_in_a_projection():
+    """The issue #50 text-argument support, on the projection side."""
+    sql = (
+        "SELECT event_id_cnty, "
+        "answer(COALESCE(notes,'') || ' ' || COALESCE(tags,''), '{}') = 'Yes' AS f "
+        "FROM events WHERE event_id_cnty IN ({}) ORDER BY event_id_cnty"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification() as stub:
+        rows, _, _ = _run(sql)
+    got = dict(rows)
+    for i in POSITIVE_IDS:
+        assert got[i] is True, (i, got)
+    # the LLM must see the whole expression, not just `notes`
+    assert stub.seen and all(
+        isinstance(f, suql_module._ComputedTextField) for _, f, _, _, _ in stub.seen
+    ), stub.seen
+
+
+def check_free_text_where_plus_projection_predicate():
+    """Both stages run: the WHERE clause filters via the retriever, then the
+    surviving rows get their projection predicate verified."""
+    sql = (
+        "SELECT event_id_cnty, answer(notes, 'Did this happen in Ukraine?') = 'Yes' AS f "
+        "FROM events WHERE event_id_cnty IN ({}) AND answer(notes, '{}') = 'Yes'"
+    ).format(ID_LITERALS, QUESTION)
+    with _StubbedVerification():
+        rows, columns, _ = _run(sql)
+    assert columns == ["event_id_cnty", "f"], columns
+    assert sorted(r[0] for r in rows) == sorted(POSITIVE_IDS), rows
+
+
+def check_plain_projection_answer_is_left_to_postgres():
+    """A projection that wants prose must not be rewritten - the compiler has
+    nothing to verify there."""
+    node = _stmt(
+        "SELECT event_id_cnty, answer(notes, 'which city?') FROM events "
+        "WHERE country = 'Ukraine'"
+    )
+    assert not _extract_projection_predicates(node)
+
+
+def check_projection_predicate_inside_a_cte():
+    """CTE bodies go through the same visitor, so a predicate in one has to be
+    verified before the outer query filters on it."""
+    sql = (
+        "WITH flagged AS ("
+        "  SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f "
+        "  FROM events WHERE event_id_cnty IN ({})"
+        ") SELECT event_id_cnty FROM flagged WHERE f"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert sorted(r[0] for r in rows) == sorted(POSITIVE_IDS), rows
+
+
+def check_cte_predicate_feeding_an_outer_aggregate():
+    sql = (
+        "WITH flagged AS ("
+        "  SELECT country, CASE WHEN answer(notes, '{}') = 'Yes' THEN 1 ELSE 0 END AS f "
+        "  FROM events WHERE event_id_cnty IN ({})"
+        ") SELECT country, SUM(f) FROM flagged GROUP BY country"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert rows == [("Ukraine", len(POSITIVE_IDS))], rows
+
+
+def check_max_verification_workers_is_honored():
+    sql = (
+        "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f FROM events "
+        "WHERE country = 'Ukraine' AND year = 2022 LIMIT 24"
+    ).format(QUESTION)
+
+    with _StubbedVerification(delay=0.2) as serial:
+        start = time.time()
+        rows, _, _ = _run(sql, max_verification_workers=1)
+        serial_elapsed = time.time() - start
+    assert len(rows) == 24, len(rows)
+    assert serial.max_inflight == 1, serial.max_inflight
+
+    with _StubbedVerification(delay=0.2) as parallel:
+        start = time.time()
+        rows, _, _ = _run(sql, max_verification_workers=12)
+        parallel_elapsed = time.time() - start
+    assert len(rows) == 24, len(rows)
+    assert parallel.max_inflight > 1, parallel.max_inflight
+    assert parallel.max_inflight <= 12, parallel.max_inflight
+    assert parallel_elapsed < serial_elapsed / 2, (parallel_elapsed, serial_elapsed)
+
+
+INTEGRATION_CHECKS = [
+    check_reported_repro,
+    check_verification_sees_the_question_and_the_literal,
+    check_aggregate_is_not_undercounted,
+    check_projection_is_boolean_not_prose,
+    check_having_and_order_by,
+    check_internal_column_does_not_leak_into_select_star,
+    check_two_questions_in_one_query,
+    check_limit_is_pushed_down_on_an_unfiltered_query,
+    check_limit_with_offset_still_returns_rows,
+    check_column_projected_under_its_own_name_resolves,
+    check_computed_text_expression_in_a_projection,
+    check_free_text_where_plus_projection_predicate,
+    check_plain_projection_answer_is_left_to_postgres,
+    check_projection_predicate_inside_a_cte,
+    check_cte_predicate_feeding_an_outer_aggregate,
+    check_max_verification_workers_is_honored,
+]
+
+
+# ---------- runner ------------------------------------------------------------
+
+def main():
+    failures = []
+    print("--- unit ---")
+    for check in UNIT_CHECKS:
+        try:
+            check()
+            print("[PASS] {}".format(check.__name__))
+        except Exception:
+            print("[FAIL] {}".format(check.__name__))
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    print("\n--- integration (real acled DB, stubbed LLM) ---")
+    for check in INTEGRATION_CHECKS:
+        try:
+            check()
+            print("[PASS] {}".format(check.__name__))
+        except Exception:
+            print("[FAIL] {}".format(check.__name__))
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    if failures:
+        print("\n{} failed: {}".format(len(failures), failures))
+        sys.exit(1)
+    print("\nall checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #57.

## The bug

`answer(col, q) = 'Yes'` behaves completely differently depending on where it appears.

In a `WHERE` clause it is compiled: the comparison becomes `(field, query, '=', 'Yes')` and goes to `_verify`, which renders `verification.prompt` — a forced two-way choice, `max_tokens=30`, passing iff the reply contains `"the answer is correct"`. The `'Yes'` is a semantic hint to the model, not a literal to match.

Anywhere else, it was not compiled at all. `visit_SelectStmt` only ever ran `freeTextFcnVisitor(node.whereClause)`, so a comparison in the SELECT list went to Postgres verbatim, which ran the raw `plpython3u` UDF — whose prompt is open-ended ("Answer a question based on the following text") — and byte-compared its free-form prose against the literal.

Reproduced on `main` against a live 1.6M-row ACLED table. Six hand-labelled rows, three of them genuine positives:

```
UKR73236 | [Yes. The Zaporizhzhia Nuclear Power Station is part of energy infrastructure.]
UKR69217 | [Yes. Shelling a nuclear power station is an attack on energy infrastructure.]
UKR88237 | [Yes. It targeted a gas pipeline, which is part of energy infrastructure.]
UKR147821| [No. It was an accidental detonation of a mine during water pipeline repair work, ...]
```

The model is 6/6 semantically correct. None of those strings equals `'Yes'`, so `CASE WHEN answer(notes, q) = 'Yes' THEN 1 ELSE 0 END` returned **0 for every row** — no error, no warning, and any aggregate built on it silently under-counts.

It was also non-deterministic. `_answer` passes `temperature=0.0`, but `prompt_continuation.py:206-210` forces `kwargs["temperature"] = 1` for anything matching `(^|/|-)gpt-5`, so every projection call is sampled. Re-running the same three rows produced different wording each time. The `WHERE` path survives this because the forced-choice format and the `_verified_res` memo cache absorb the variance; the projection path had neither.

## The fix

Recognise `answer(...) <op> <literal>` in the projection, `HAVING`, `GROUP BY` and `ORDER BY`; verify it per row through the same `_verify` path a `WHERE` predicate takes; materialize each distinct comparison as one synthetic boolean column in the temp table and rewrite the comparison to reference it. No `answer()` call reaches Postgres.

Covered shapes:

```sql
answer(notes, q) = 'Yes' AS is_attack                      -- bare boolean projection
CASE WHEN answer(notes, q) = 'Yes' THEN 1 ELSE 0 END       -- the reported one
SUM(CASE WHEN answer(notes, q) = 'Yes' THEN 1 ELSE 0 END)  -- where the undercount bites
COUNT(*) FILTER (WHERE answer(notes, q) = 'Yes')
HAVING bool_or(answer(notes, q) = 'Yes')
ORDER BY answer(notes, q) = 'Yes' DESC
```

Identical comparisons written twice share a column and are verified once (the alias is an md5 of the comparison's SQL text). A bare `SELECT *` alongside such a predicate is expanded to the explicit column list so the synthetic column does not leak into results.

Deliberately left to Postgres, unchanged:

- `SELECT answer(notes, 'which city?')` — the prose is the point.
- `answer(a, q) = other_column` — no literal, so there is no candidate answer to put in the prompt.
- `lower(answer(...)) = 'yes'`, `answer(...) ILIKE 'yes%'` — the call is not the comparison operand, so substituting a boolean would not typecheck. Worth handling later by stripping a whitelist of wrappers.
- `answer(...)::int` — a cast is a value use; `_TypeCastAnswer` already owns it.

An aggregate in the text argument (`answer(string_agg(notes,' '), q)`) now raises `NotImplementedError` rather than silently collapsing to one row — the compiler evaluates that argument once per *input* row, before grouping.

### Design note: why there is no retrieval step

A `WHERE` predicate gets to prune, so it can be answered from the retriever's top-k. A projection cannot — the query must emit a value for every row it outputs, and a row the retriever happens to miss would become exactly the silent false negative this PR is fixing. So every surviving row is verified.

## Parallelism

That makes this rows × predicates LLM calls, all mutually independent — which is the easy case, and moving the calls out of the Postgres backend is what makes it possible at all (the UDF is `VOLATILE` + `PARALLEL UNSAFE`, so in-database it is strictly serial).

Both this path and the existing `_parallel_filtering` now size their pool from a new `max_verification_workers` parameter on `suql_execute` (default 32, `SUQL_MAX_VERIFICATION_WORKERS` env override) instead of an unconfigured `ThreadPoolExecutor`, whose size is `min(32, cpu_count + 4)` — a function of the local core count, when the real ceiling is the provider's rate limit. Calls go into one flat pool rather than being nested per row: `_verify_single_res` short-circuits on the first false predicate, which is right for a filter and wrong here, since every predicate's value is needed regardless.

Measured over 64 rows with a 0.25s stub:

| workers | max in-flight | wall clock |
|---|---|---|
| 1 | 1 | 16.8s |
| 4 | 4 | 4.9s |
| 32 | 32 | 1.3s |

Where nothing downstream can change which rows the query outputs (no `GROUP BY`/`HAVING`/`ORDER BY`/`DISTINCT`/`OFFSET`), the `LIMIT` is pushed down ahead of verification. `SELECT ..., answer(...) = 'Yes' FROM events LIMIT 3` costs 3 LLM calls, not 1.6M.

## Two further bugs, both found reviewing this change

1. **`LIMIT n OFFSET m` returned zero rows.** The limit was pushed into the structural query and the rewritten query then applied the same `OFFSET` a second time against the temp table. Pushdown now requires no `OFFSET`.
2. **A text column projected under its own name** (e.g. a subquery in `FROM`) raised instead of resolving.

Also: `_FreeTextFcnVisitor` now tolerates a `None` clause, which the old `if not node.whereClause: return` guard used to hide — needed now that a query with no `WHERE` at all can reach the compiler.

## Testing

`tests/test_projection_answer.py` — 13 unit + 16 integration checks against the live `acled` DB with only the LLM call stubbed, so the structural SQL, temp table, rewritten query and the documents that would reach the model are all real. All pass.

Separately verified end to end against a real model (12/12 scenarios), including CTEs, the mixed free-text-`WHERE` + projection case, and an assertion that no `answer(` reaches Postgres:

```
before:  UKR73236|0  UKR69217|0  UKR88237|0    (0/3 true positives)
after:   UKR73236|1  UKR69217|1  UKR88237|1    (3/3, negatives correctly 0)
SUM(CASE WHEN ...) = 3
```

Regressions: `tests/test_computed_text_answer.py` and `tests/test_star_expansion.py` pass. `tests/test_cte_materialization.py` fails identically before and after this change on my box (25 unit checks pass, then `RateLimitError: no credits remaining` — it uses no stubs by design, so it cannot run without live LLM credentials).

## Not addressed here

The forced `temperature=1` for gpt-5 in `prompt_continuation.py:206-210` is untouched. It no longer affects these comparisons, but still makes bare prose `answer()` projections non-deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

