### PR TITLE
fix(compiler): CTE materialization information loss + per-query verification cost ceiling (1.1.10a4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to SUQL are documented in this file. Format loosely follows
 ## [Unreleased]
 
 ### Fixed
+- **`answer()` comparisons outside the WHERE clause.**
+  `CASE WHEN answer(notes, q) = 'Yes' THEN 1 ELSE 0 END` in a SELECT list
+  returned 0 for rows the model had answered correctly, with no error — silently
+  under-counting aggregates. Only `node.whereClause` was ever compiled, so a
+  comparison in the projection was handed to Postgres, which ran the raw
+  plpython3u UDF (whose prompt is open-ended: "Answer a question based on the
+  following text") and byte-compared its free-form prose against the literal.
+  `Yes. A nuclear power station is part of energy infrastructure.` is not
+  `'Yes'`. It also varied run to run, because `prompt_continuation` forces
+  `temperature=1` for the gpt-5 family regardless of the caller's request.
+  The compiler now recognises `answer(...) <op> <literal>` in the projection,
+  `HAVING`, `GROUP BY` and `ORDER BY`, verifies each one per row through the
+  same path a WHERE predicate takes, and materializes the result as a synthetic
+  boolean column. A bare `SELECT *` alongside such a predicate is expanded to
+  the explicit column list so the synthetic column doesn't leak. Uses that want
+  the model's prose (`SELECT answer(notes, 'which city?')`), comparisons against
+  a non-literal, and calls wrapped in another function (`lower(answer(...))`)
+  are left for Postgres as before; an aggregate in the text argument raises
+  `NotImplementedError` rather than silently collapsing to one row.
+
 - **`answer()` over a computed text expression (issue #50).** The text argument
   of a free-text function no longer has to be a bare column: `answer(COALESCE(a,
   '') || ' ' || COALESCE(b, ''), '...')`, `answer(lower(notes), '...')` and any
@@ -27,6 +47,20 @@ All notable changes to SUQL are documented in this file. Format loosely follows
   the original table name as an alias.
 - `answer()` on a NULL text value is now `False` instead of raising an
   `AssertionError` inside verification.
+
+### Changed
+- **Verification LLM calls are explicitly pooled.** Both the WHERE-side filter
+  and the new projection-side path run their verifications through a thread pool
+  sized by `max_verification_workers` (new `suql_execute(...)` parameter,
+  default 32, overridable process-wide with `SUQL_MAX_VERIFICATION_WORKERS`).
+  Previously `_parallel_filtering` constructed an unconfigured
+  `ThreadPoolExecutor`, whose size is `min(32, cpu_count + 4)` — a function of
+  the local core count, when the real ceiling is the LLM provider's rate limit.
+  A projection predicate cannot prune, so it is verified on every output row;
+  the calls are all mutually independent and go into one flat pool rather than
+  being nested per row. Where the query's `LIMIT` cannot be changed by anything
+  downstream (no `GROUP BY`/`HAVING`/`ORDER BY`/`DISTINCT`), it is pushed down
+  ahead of verification, which bounds the number of LLM calls.
 
 ## [1.1.10a3] - 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to SUQL are documented in this file. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- **Per-query verification cost ceiling (`max_verification_cost`, default
+  $1.00).** Nothing previously bounded what one query could spend verifying
+  `answer(...)` predicates. A reported run ground for 25 hours on 4,326,211
+  verification calls costing $101.51 without a single query completing — broad
+  free-text predicates over a large candidate set. Parallelising verification
+  made that faster, not cheaper.
+
+  Enforced at `_verify`, the single point every compiler-side verification
+  passes through, so it covers both the retriever-backed WHERE path and
+  projection predicates. Two mechanisms:
+  - *Stop*: accumulated spend is checked before every verification, so a query
+    can never run past its ceiling.
+  - *Refuse early*: after a small sample of real calls (25), the mean cost per
+    verification is extrapolated over the number still planned; if the
+    projection exceeds the ceiling the query is refused immediately. A plan of
+    176,660 verifications is now refused in ~12 seconds having spent $0.0006,
+    with a message giving the plan size, the measured rate, the projection and
+    the limit.
+
+  Exceeding the ceiling raises `SUQLCostLimitExceeded` (exported from `suql`)
+  rather than returning a half-applied filter as if it were the complete
+  answer. Cost is projected per verification *attempt*, so documents served
+  from the `_verified_res` memo cache do not inflate the estimate; the planned
+  count for a multi-predicate WHERE clause is an upper bound, so the projection
+  errs toward refusing. Override per call, or process-wide with
+  `SUQL_MAX_VERIFICATION_COST`; pass `0` to remove the ceiling.
+  `max_verification_calls` (and `SUQL_MAX_VERIFICATION_CALLS`) caps the call
+  count instead. `cache["_stats"]` now also reports `verifications` and
+  `max_verification_cost`.
+
+  Scope: this bounds spend made in the SUQL process. `answer()` left in a
+  projection for Postgres to evaluate as the raw plpython3u UDF calls the
+  free-text server directly and is not covered; that path is still only visible
+  after the fact via `/stats/<query_id>`. The ceiling is also per
+  `suql_execute` call — a pipeline issuing many queries needs its own aggregate
+  budget on top.
+
 ### Fixed
 - **CTE materialization dropped information the rest of the query needed.**
   Four distinct failures, all from materializing a CTE containing `answer()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to SUQL are documented in this file. Format loosely follows
 ## [Unreleased]
 
 ### Fixed
+- **CTE materialization dropped information the rest of the query needed.**
+  Four distinct failures, all from materializing a CTE containing `answer()`
+  and then losing something across the boundary. Reported together from one
+  pipeline run in which 12/12 SUQL executions failed.
+  - *The name a CTE is referred to by.* `_rewrite_cte_refs` swapped
+    `RangeVar.relname` for the temp table without keeping the old name, so
+    `SELECT base.event_id_cnty ... FROM base` became `... FROM temp_table_xxx`
+    and Postgres rejected it with `missing FROM-clause entry for table "base"`.
+    The same happened to an explicit alias (`FROM base b` … `SELECT b.*`),
+    which `visit_SelectStmt` then overwrote with the temp table's own name. The
+    referenced name is now preserved as an alias, and an existing alias is
+    carried across instead of being replaced.
+  - *The CTE's own output columns.* A CTE was treated as "materialized" if its
+    FROM clause named a temp table — which is also true when it merely *reads*
+    from an upstream CTE's temp table. Downstream references were then
+    redirected to that upstream table, dropping every column the body computed
+    (`column "russian_yes" does not exist`). Redirection now requires that the
+    body actually reduce to `SELECT * FROM <temp table>`; when it does not, the
+    body's own output is materialized first.
+  - *The row ID.* A CTE that does not project its source table's ID column
+    (`SELECT country, admin1, notes FROM events`) could not be registered in
+    `table_w_ids`, and a downstream `answer()` failed with a bare
+    `KeyError: 'temp_table_xxx'`. The ID is now added back to such a CTE before
+    it is materialized. Only CTEs materialized as *input* to a later `answer()`
+    are touched, so this does not change what `SELECT * FROM <cte>` returns.
+  - *Cases that genuinely have no row ID* (a CTE that aggregates) now raise an
+    actionable `NotImplementedError` naming the relation and the ID columns it
+    could project, instead of a `KeyError` on an internal table name.
 - **`answer()` comparisons outside the WHERE clause.**
   `CASE WHEN answer(notes, q) = 'Yes' THEN 1 ELSE 0 END` in a SELECT list
   returned 0 for rows the model had answered correctly, with no error — silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to SUQL are documented in this file. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.1.10a4] - 2026-08-11
+
+### Changed (behavioural — read before upgrading)
+- **`answer(...)` verification is now capped at $1.00 per query by default.**
+  Previously nothing bounded it. A query that used to run to completion while
+  spending more than that now raises `SUQLCostLimitExceeded` instead of
+  returning results. Pass `max_verification_cost=<usd>` to raise the ceiling,
+  or `0` to restore the old unbounded behaviour. See the entry below for why
+  the default is on rather than opt-in.
 
 ### Added
 - **Per-query verification cost ceiling (`max_verification_cost`, default

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 # Package metadata
 name = "suql"
-version = "1.1.10a3"
+version = "1.1.10a4"
 description = "Structured and Unstructured Query Language (SUQL) Python API"
 author = "Shicheng Liu"
 author_email = "shicheng@cs.stanford.edu"

--- a/src/suql/__init__.py
+++ b/src/suql/__init__.py
@@ -1,1 +1,4 @@
-from suql.sql_free_text_support.execute_free_text_sql import suql_execute
+from suql.sql_free_text_support.execute_free_text_sql import (
+    SUQLCostLimitExceeded,
+    suql_execute,
+)

--- a/src/suql/sql_free_text_support/execute_free_text_sql.py
+++ b/src/suql/sql_free_text_support/execute_free_text_sql.py
@@ -7,6 +7,7 @@ import os
 import random
 import re
 import string
+import threading
 import time
 import traceback
 from collections import defaultdict
@@ -539,6 +540,170 @@ def _resolve_max_workers(max_workers=None):
                 "ignoring non-integer SUQL_MAX_VERIFICATION_WORKERS=%r", from_env
             )
     return _DEFAULT_MAX_VERIFICATION_WORKERS
+
+
+class SUQLCostLimitExceeded(RuntimeError):
+    """Raised when a query's verification spend hits (or is projected to hit)
+    the per-query cost/call ceiling. Deliberately loud: the alternative is
+    returning a partial filter as if it were the complete answer."""
+
+
+# Per-query verification budget. A ContextVar so it reaches the worker threads
+# in _parallel_map / _parallel_filtering, both of which run tasks under
+# contextvars.copy_context().
+_verification_budget: contextvars.ContextVar = contextvars.ContextVar(
+    "_verification_budget", default=None
+)
+
+# Default ceiling on what one suql_execute() call may spend on verification.
+_DEFAULT_MAX_VERIFICATION_COST = 1.0
+
+# Real LLM calls to observe before extrapolating a batch's total cost. Small
+# enough to be negligible against any sane ceiling, large enough to smooth out
+# per-document length variation.
+_COST_PROJECTION_SAMPLE = 25
+
+
+class _VerificationBudget:
+    """Hard ceiling on verification spend for a single query.
+
+    Two mechanisms, because a ceiling alone is not enough:
+
+    - **Stop**: before every verification the accumulated spend is checked, so a
+      query can never run past its ceiling.
+    - **Refuse early**: a query whose plan is 4.3M verifications should not
+      spend its entire ceiling discovering that. After a small sample of real
+      calls, the mean cost per verification is extrapolated over the number
+      still planned; if that projection exceeds the ceiling, the query is
+      refused immediately with the numbers that justify it.
+
+    The projection is measured per *verification attempt*, not per LLM call, so
+    documents served from the `_verified_res` memo cache are accounted for
+    rather than inflating the estimate.
+
+    Only spend made in this process is visible here. `answer()` evaluated by
+    Postgres as the raw plpython3u UDF calls the free-text server directly and
+    is not counted; that path is reported by `/stats/<query_id>` after the fact.
+    """
+
+    def __init__(self, max_cost=None, max_calls=None, tracker=None):
+        self.max_cost = max_cost
+        self.max_calls = max_calls
+        self._tracker = tracker
+        self._lock = threading.Lock()
+        self._planned = 0
+        self._attempts = 0
+        self._tripped = None
+
+    def _spend(self):
+        if self._tracker is None:
+            return 0.0, 0
+        with self._tracker["_lock"]:
+            return self._tracker["cost"], self._tracker["calls"]
+
+    def register_planned(self, count):
+        """Declare `count` more verifications are about to be attempted."""
+        with self._lock:
+            self._planned += max(0, int(count))
+
+    def snapshot(self):
+        cost, calls = self._spend()
+        with self._lock:
+            return {
+                "cost": cost,
+                "llm_calls": calls,
+                "verifications": self._attempts,
+                "planned": self._planned,
+                "max_cost": self.max_cost,
+                "max_calls": self.max_calls,
+            }
+
+    def _trip(self, message):
+        with self._lock:
+            if self._tripped is None:
+                self._tripped = message
+        raise SUQLCostLimitExceeded(self._tripped)
+
+    def before_verification(self):
+        """Called immediately before each verification. Raises to stop the query."""
+        with self._lock:
+            if self._tripped is not None:
+                raise SUQLCostLimitExceeded(self._tripped)
+            self._attempts += 1
+            attempts = self._attempts
+            planned = self._planned
+
+        cost, calls = self._spend()
+
+        if self.max_calls is not None and calls >= self.max_calls:
+            self._trip(
+                "verification call limit reached: {} LLM calls (limit {}), "
+                "${:.4f} spent. Narrow the query with structural predicates or "
+                "raise max_verification_calls.".format(calls, self.max_calls, cost)
+            )
+
+        if self.max_cost is None:
+            return
+
+        if cost >= self.max_cost:
+            self._trip(
+                "verification cost limit reached: ${:.4f} spent over {} LLM "
+                "call(s) (limit ${:.2f}). Narrow the query with structural "
+                "predicates, add a LIMIT, or raise "
+                "max_verification_cost.".format(cost, calls, self.max_cost)
+            )
+
+        # Extrapolate once there is enough signal, so an unaffordable plan is
+        # refused after cents rather than after the whole ceiling.
+        if calls >= _COST_PROJECTION_SAMPLE and planned > attempts:
+            per_verification = cost / attempts
+            projected = per_verification * planned
+            if projected > self.max_cost:
+                self._trip(
+                    "refusing to continue: {:,} verifications are planned and "
+                    "the first {:,} cost ${:.4f} (${:.6f} each), so this query "
+                    "projects to ${:.2f} - over the ${:.2f} limit. Narrow the "
+                    "query with structural predicates, add a LIMIT, or raise "
+                    "max_verification_cost.".format(
+                        planned, attempts, cost, per_verification,
+                        projected, self.max_cost,
+                    )
+                )
+
+
+def _resolve_verification_budget(max_cost, max_calls, tracker):
+    """Builds the per-query budget, applying env overrides and the default
+    ceiling. `max_cost=0` (or a negative value) disables the cost ceiling."""
+
+    def _from_env(name, cast):
+        raw = os.environ.get(name)
+        if not raw:
+            return None
+        try:
+            return cast(raw)
+        except ValueError:
+            logging.warning("ignoring non-numeric %s=%r", name, raw)
+            return None
+
+    if max_cost is None:
+        max_cost = _from_env("SUQL_MAX_VERIFICATION_COST", float)
+    if max_cost is None:
+        max_cost = _DEFAULT_MAX_VERIFICATION_COST
+    if max_cost is not None and max_cost <= 0:
+        max_cost = None
+
+    if max_calls is None:
+        max_calls = _from_env("SUQL_MAX_VERIFICATION_CALLS", int)
+    if max_calls is not None and max_calls <= 0:
+        max_calls = None
+
+    return _VerificationBudget(max_cost=max_cost, max_calls=max_calls, tracker=tracker)
+
+
+def _register_planned_verifications(count):
+    budget = _verification_budget.get()
+    if budget is not None:
+        budget.register_planned(count)
 
 
 def _parallel_map(fcn, items, max_workers=None):
@@ -1582,6 +1747,13 @@ def _verify(
     if (document, field, query, operator, value) in _verified_res:
         return _verified_res[(document, field, query, operator, value)]
 
+    # Every compiler-side verification funnels through here, so this is where
+    # the per-query ceiling is enforced. Raises SUQLCostLimitExceeded to stop
+    # the query rather than returning a half-applied filter.
+    budget = _verification_budget.get()
+    if budget is not None:
+        budget.before_verification()
+
     # construct the answer part
     if operator == "=":
         answer = value
@@ -1882,6 +2054,9 @@ def _verify_projection_predicates(
         plan.append((alias, column_index, field, query, operator, value))
 
     tasks = [(row, entry) for row in results for entry in plan]
+    # Declare the size of the plan so the budget can refuse an unaffordable
+    # one after a sample rather than after spending the whole ceiling.
+    _register_planned_verifications(len(tasks))
 
     def verify_one(task):
         row, (_, column_index, field, query, operator, value) = task
@@ -2234,6 +2409,12 @@ def _retrieve_and_verify(
             if res not in filtered_parsed_result:
                 filtered_parsed_result.append(res)
         parsed_result = filtered_parsed_result
+
+    # Upper bound on the verifications this batch can attempt: every candidate
+    # row against every predicate. _verify_single_res short-circuits on the
+    # first predicate a row fails, so the real count is often lower - but the
+    # budget must be told the worst case it is being asked to fund.
+    _register_planned_verifications(len(parsed_result) * max(1, len(field_query_list)))
 
     if parallel:
         # parallelize verification calls
@@ -3706,6 +3887,8 @@ def suql_execute(
     disable_retriever=False,
     enable_classifier=False,
     max_verification_workers=None,
+    max_verification_cost=None,
+    max_verification_calls=None,
 ):
     """
     Main entry point to the SUQL Python-based compiler.
@@ -3774,6 +3957,21 @@ def suql_execute(
         rate limits rather than the local core count. Defaults to 32, overridable process-wide
         with the `SUQL_MAX_VERIFICATION_WORKERS` environment variable.
 
+    `max_verification_cost` (float, optional): Hard ceiling, in USD, on what this query may
+        spend verifying `answer(...)` predicates. Defaults to $1.00; override process-wide with
+        `SUQL_MAX_VERIFICATION_COST`, or pass `0` to remove the ceiling. Enforced two ways: the
+        accumulated spend is checked before every verification, and once enough calls have been
+        made to measure a mean, the cost of the remaining planned verifications is extrapolated
+        — so a query that would cost far more is refused after cents rather than after the whole
+        budget. Exceeding it raises `SUQLCostLimitExceeded`; a partial filter is never returned
+        as if it were the complete answer. Note this covers compiler-side verification only —
+        `answer()` left in a projection for Postgres to run calls the free-text server directly
+        and is reported after the fact via `/stats/<query_id>`.
+
+    `max_verification_calls` (int, optional): Ceiling on the number of verification LLM calls,
+        as an alternative to (or alongside) the cost ceiling. Off by default; override with
+        `SUQL_MAX_VERIFICATION_CALLS`.
+
     # Returns:
     `results` (List[[*]]): A list of returned database results. Each inner list stores a row of returned result.
 
@@ -3819,6 +4017,13 @@ def suql_execute(
     query_id = str(uuid4())
     tracker = make_query_tracker()
     token = set_query_tracker(tracker)
+
+    # Per-query verification ceiling. Installed on a ContextVar so it reaches
+    # the verification worker threads, which run under copy_context().
+    budget = _resolve_verification_budget(
+        max_verification_cost, max_verification_calls, tracker
+    )
+    budget_token = _verification_budget.set(budget)
 
     # Per-call I/O logging. `debug_log=True` writes to the default path;
     # passing a string uses that path; None/False disables.
@@ -3871,6 +4076,7 @@ def suql_execute(
         )
     finally:
         _query_tracker.reset(token)
+        _verification_budget.reset(budget_token)
 
     # Collect SELECT-projection answer() costs from the free text server
     flask_stats = {"cost": 0.0, "calls": 0}
@@ -3887,6 +4093,8 @@ def suql_execute(
     cache["_stats"] = {
         "cost": tracker["cost"] + flask_stats.get("cost", 0.0),
         "calls": tracker["calls"] + flask_stats.get("calls", 0),
+        "verifications": budget.snapshot()["verifications"],
+        "max_verification_cost": budget.max_cost,
     }
 
     if results == []:

--- a/src/suql/sql_free_text_support/execute_free_text_sql.py
+++ b/src/suql/sql_free_text_support/execute_free_text_sql.py
@@ -3,12 +3,14 @@ import contextvars
 import hashlib
 import json
 import logging
+import os
 import random
 import re
 import string
 import time
 import traceback
 from collections import defaultdict
+from contextlib import contextmanager
 from copy import deepcopy
 from functools import lru_cache
 from typing import Dict, List, NamedTuple, Union
@@ -22,7 +24,7 @@ from pglast.ast import *
 from pglast.enums.parsenodes import A_Expr_Kind
 from pglast.enums.primnodes import BoolExprType, CoercionForm
 from pglast.stream import RawStream
-from pglast.visitors import Ancestor, Visitor
+from pglast.visitors import Ancestor, Skip, Visitor
 from psycopg2 import Error as psyconpg2Error
 from sympy import Symbol, symbols
 from sympy.logic.boolalg import And, Not, Or, to_dnf
@@ -57,6 +59,10 @@ class _FreeTextFcnVisitor(Visitor):
         self.res = False
 
     def __call__(self, node):
+        # absent clauses (a missing WHERE, the empty side of a unary operator)
+        # contain no free text functions
+        if node is None:
+            return
         super().__call__(node)
 
     def visit_FuncCall(self, ancestors, node: pglast.ast.FuncCall):
@@ -212,6 +218,310 @@ def _drop_internal_columns(results, column_info):
     )
 
 
+# Prefix for the synthetic boolean columns that hold the verified value of a
+# free text comparison appearing outside the WHERE clause (see
+# `_verify_projection_predicates`). Unlike `_INTERNAL_EXPR_COLUMN_PREFIX` these
+# columns are *referenced* by the rewritten query, so they do live in the temp
+# table; `*` is expanded explicitly so they don't leak into the user's results.
+_INTERNAL_PRED_COLUMN_PREFIX = "_suql_pred_"
+
+# Aggregates may not appear in the text argument of a free text function that
+# the compiler evaluates: the compiler reads that argument off the structural
+# query one value per *input* row, before any grouping has happened.
+_KNOWN_AGGREGATE_FCNS = frozenset(
+    [
+        "array_agg",
+        "avg",
+        "bit_and",
+        "bit_or",
+        "bool_and",
+        "bool_or",
+        "count",
+        "every",
+        "json_agg",
+        "json_object_agg",
+        "jsonb_agg",
+        "jsonb_object_agg",
+        "max",
+        "min",
+        "stddev",
+        "stddev_pop",
+        "stddev_samp",
+        "string_agg",
+        "sum",
+        "var_pop",
+        "var_samp",
+        "variance",
+    ]
+)
+
+
+class _ContainsAggregate(Visitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.res = False
+
+    def __call__(self, node):
+        if node is None:
+            return
+        super().__call__(node)
+
+    def visit_FuncCall(self, ancestors, node: FuncCall):
+        if node.agg_star or node.agg_distinct or node.agg_order or node.agg_filter:
+            self.res = True
+            return
+        name = ".".join(i.sval for i in node.funcname if isinstance(i, String))
+        if name.rsplit(".", 1)[-1].lower() in _KNOWN_AGGREGATE_FCNS:
+            self.res = True
+
+
+def _contains_aggregate(node):
+    visitor = _ContainsAggregate()
+    visitor(node)
+    return visitor.res
+
+
+def _projection_predicate_alias(predicate_sql: str):
+    """Deterministic column name for a verified free text comparison. Derived
+    from the comparison's SQL text so the same comparison written twice (e.g. in
+    both the projection and ORDER BY) is verified once."""
+    digest = hashlib.md5(predicate_sql.encode("utf-8")).hexdigest()[:12]
+    return _INTERNAL_PRED_COLUMN_PREFIX + digest
+
+
+def _if_projection_predicate(node):
+    """True if `node` is an `answer(...) <op> <literal>` comparison.
+
+    Outside the WHERE clause such a comparison is currently handed to Postgres
+    verbatim, which runs the raw `answer` UDF and string-compares its free-form
+    prose against the literal - so `CASE WHEN answer(notes, q) = 'Yes'` is
+    almost always false even when the model says yes. These are exactly the
+    shapes that can instead be routed through the same verification path a WHERE
+    predicate takes.
+    """
+    if not isinstance(node, A_Expr) or node.kind != A_Expr_Kind.AEXPR_OP:
+        return False
+    if len(node.name) != 1 or not isinstance(node.name[0], String):
+        return False
+
+    lexpr_is_free_text = _if_contains_free_text_fcn(node.lexpr)
+    rexpr_is_free_text = _if_contains_free_text_fcn(node.rexpr)
+    if lexpr_is_free_text == rexpr_is_free_text:
+        # free text on both sides, or on neither - nothing to verify
+        return False
+
+    free_text_clause = node.lexpr if lexpr_is_free_text else node.rexpr
+    value_clause = node.rexpr if lexpr_is_free_text else node.lexpr
+
+    # `lower(answer(...)) = 'yes'` and friends wrap the call in a normalizing
+    # function. The free text call has to be the operand itself for the rewrite
+    # to stay type-correct, since the replacement is a boolean.
+    if not _if_free_text_fcn(free_text_clause):
+        return False
+    args = free_text_clause.args if free_text_clause.args else ()
+    if len(args) < 2:
+        return False
+    if not (isinstance(args[1], A_Const) and isinstance(args[1].val, String)):
+        return False
+
+    # the compared-against value has to be a literal - it is what gets shown to
+    # the verification prompt as the candidate answer
+    return isinstance(value_clause, A_Const) and isinstance(
+        value_clause.val, (String, Integer)
+    )
+
+
+class _ProjectionPredicateVisitor(Visitor):
+    """Collects `answer(...) <op> <literal>` comparisons, and (when `replace` is
+    set) swaps each one for a reference to the synthetic boolean column the
+    compiler materializes for it."""
+
+    def __init__(self, replace=False) -> None:
+        super().__init__()
+        self.replace = replace
+        self.res: Dict[str, tuple] = {}
+
+    def __call__(self, node):
+        if node is None:
+            return
+        return super().__call__(node)
+
+    def visit_SelectStmt(self, ancestors, node: SelectStmt):
+        # A nested SelectStmt (e.g. a scalar subquery in the target list) owns
+        # its own projection; the outer visitor reaches it separately.
+        if node is not self.root:
+            return Skip
+
+    def visit_A_Expr(self, ancestors, node: A_Expr):
+        if not _if_projection_predicate(node):
+            return
+
+        lexpr_is_free_text = _if_contains_free_text_fcn(node.lexpr)
+        free_text_clause = node.lexpr if lexpr_is_free_text else node.rexpr
+        value_clause = node.rexpr if lexpr_is_free_text else node.lexpr
+
+        text_arg, query = _free_text_fcn_args(free_text_clause)
+        if _contains_aggregate(text_arg):
+            raise NotImplementedError(
+                "the text argument of a free text function outside the WHERE "
+                "clause is evaluated once per input row, so it cannot contain "
+                "an aggregate: {}".format(RawStream()(free_text_clause))
+            )
+
+        value = (
+            value_clause.val.sval
+            if isinstance(value_clause.val, String)
+            else value_clause.val.ival
+        )
+        alias = _projection_predicate_alias(RawStream()(node))
+        self.res[alias] = (text_arg, query, node.name[0].sval, value)
+
+        if self.replace:
+            return ColumnRef(fields=(String(sval=alias),))
+
+
+@contextmanager
+def _only_projection_clauses(node: SelectStmt):
+    """Hides the parts of a SelectStmt that the compiler handles elsewhere, so a
+    visitor sees only the projection, HAVING, GROUP BY and ORDER BY.
+
+    The WHERE clause has its own (retrieval-backed) pipeline; CTE bodies are
+    materialized by `_process_ctes`; FROM-clause subqueries are separate
+    SelectStmts that the outer visitor reaches on its own.
+    """
+    saved = (node.whereClause, node.withClause, node.fromClause)
+    node.whereClause = None
+    node.withClause = None
+    node.fromClause = None
+    try:
+        yield
+    finally:
+        node.whereClause, node.withClause, node.fromClause = saved
+
+
+def _extract_projection_predicates(node: SelectStmt, replace=False):
+    """Free text comparisons living outside the WHERE clause, keyed by the
+    synthetic boolean column each will be materialized under."""
+    visitor = _ProjectionPredicateVisitor(replace=replace)
+    with _only_projection_clauses(node):
+        visitor(node)
+    return visitor.res
+
+
+def _expand_star_targets(node: SelectStmt, column_info):
+    """Replaces a bare `*` in the target list with the explicit column list.
+
+    Needed once the compiler appends synthetic boolean columns to the temp
+    table: `SELECT *` against that table would otherwise hand the user the
+    compiler's internal columns.
+    """
+    names = [
+        x[0]
+        for x in column_info
+        if not str(x[0]).startswith(_INTERNAL_PRED_COLUMN_PREFIX)
+    ]
+    expanded = []
+    changed = False
+    for target in node.targetList or ():
+        if (
+            isinstance(target, ResTarget)
+            and isinstance(target.val, ColumnRef)
+            and len(target.val.fields) == 1
+            and isinstance(target.val.fields[0], A_Star)
+        ):
+            changed = True
+            expanded.extend(
+                ResTarget(val=ColumnRef(fields=(String(sval=name),))) for name in names
+            )
+        else:
+            expanded.append(target)
+    if changed:
+        node.targetList = tuple(expanded)
+
+
+def _if_limit_pushdown_safe(node: SelectStmt):
+    """Whether the query's LIMIT can be applied while fetching the rows that
+    projection predicates will be verified against.
+
+    A projection predicate filters nothing, so the rows the query outputs are
+    already determined by the structural part - unless something downstream can
+    reorder or regroup them first.
+
+    An OFFSET is excluded because the rewritten query runs against the temp
+    table and would apply the same OFFSET a second time, skipping past rows that
+    were already skipped once.
+    """
+    return (
+        node.limitCount is not None
+        and node.limitOffset is None
+        and not node.groupClause
+        and not node.havingClause
+        and not node.sortClause
+        and not node.distinctClause
+    )
+
+
+def _extract_compiler_evaluated_computed_text_args(node: SelectStmt):
+    """Computed text arguments of free text functions in every clause the
+    compiler evaluates itself - the WHERE clause plus, since these comparisons
+    are now verified rather than executed, the projection / HAVING / GROUP BY /
+    ORDER BY."""
+    res = dict(_extract_computed_text_args(node.whereClause))
+    for clause in (
+        node.targetList,
+        node.havingClause,
+        node.groupClause,
+        node.sortClause,
+    ):
+        if clause:
+            res.update(_extract_computed_text_args(clause))
+    return res
+
+
+# Number of verification calls kept in flight. These are HTTP round trips to an
+# LLM, so the useful number is a function of the provider's rate limits, not of
+# the local core count (which is what an unconfigured ThreadPoolExecutor uses).
+_DEFAULT_MAX_VERIFICATION_WORKERS = 32
+
+
+def _resolve_max_workers(max_workers=None):
+    if max_workers is not None:
+        return max(1, int(max_workers))
+    from_env = os.environ.get("SUQL_MAX_VERIFICATION_WORKERS")
+    if from_env:
+        try:
+            return max(1, int(from_env))
+        except ValueError:
+            logging.warning(
+                "ignoring non-integer SUQL_MAX_VERIFICATION_WORKERS=%r", from_env
+            )
+    return _DEFAULT_MAX_VERIFICATION_WORKERS
+
+
+def _parallel_map(fcn, items, max_workers=None):
+    """Runs `fcn` over `items` concurrently, preserving input order.
+
+    Like `_parallel_filtering` this is an I/O-bound fan-out (each call waits on
+    an LLM HTTP response), and it copies the calling context into each worker so
+    the per-query cost tracker stays visible. Unlike `_parallel_filtering` there
+    is no early exit and results are keyed by position, so duplicate items are
+    handled correctly.
+    """
+    if not items:
+        return []
+    results = [None] * len(items)
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=_resolve_max_workers(max_workers)
+    ) as executor:
+        futures = {
+            executor.submit(contextvars.copy_context().run, fcn, item): index
+            for index, item in enumerate(items)
+        }
+        for future in concurrent.futures.as_completed(futures):
+            results[futures[future]] = future.result()
+    return results
+
+
 def _extract_all_free_text_fcns(suql):
     node = parse_sql(suql)
     visitor = _ExtractAllFreeTextFncs()
@@ -359,9 +669,12 @@ class _SelectVisitor(Visitor):
         port="5432",
         disable_retriever=False,
         enable_classifier=False,
+        max_verification_workers=None,
     ) -> None:
         super().__init__()
         self.tmp_tables = []
+        # concurrency cap for verification LLM calls (see _resolve_max_workers)
+        self.max_verification_workers = max_verification_workers
         # this cache is to store classifier results for sturctured fields (e.g. cuisines in restaurants)
         self.cache = defaultdict(dict)
         self.fts_fields = fts_fields
@@ -432,47 +745,99 @@ class _SelectVisitor(Visitor):
             else:
                 self._process_ctes(node)
 
-        if not node.whereClause:
+        # `answer(...) = 'Yes'` outside the WHERE clause (in the projection,
+        # HAVING or ORDER BY) is verified by the compiler too, rather than being
+        # left for Postgres to run as the raw UDF and string-compare.
+        # Detect it up front so a query with no WHERE clause at all still gets
+        # compiled.
+        has_projection_predicates = bool(_extract_projection_predicates(node))
+
+        if not node.whereClause and not has_projection_predicates:
             return
 
         # First, understand whether this involves subquery. If it does, then starts with that first and builds upwards
         # If that subquery in turn involves other subqueries, then recursive calls take care of it
-        subquery_visitor = _IfInvovlesSubquery()
-        subquery_visitor(node)
-        sublinks = subquery_visitor.return_top_level_sublinks()
-        for sublink in sublinks:
-            self.visit_SelectStmt(None, sublink)
+        if node.whereClause:
+            subquery_visitor = _IfInvovlesSubquery()
+            subquery_visitor(node)
+            sublinks = subquery_visitor.return_top_level_sublinks()
+            for sublink in sublinks:
+                self.visit_SelectStmt(None, sublink)
 
         freeTextFcnVisitor = _FreeTextFcnVisitor()
         freeTextFcnVisitor(node.whereClause)
 
-        if freeTextFcnVisitor.res:
+        if freeTextFcnVisitor.res or has_projection_predicates:
             tmp_table_name = "temp_table_{}".format(_generate_random_string())
 
-            # main entry point for SUQL compiler optimization
-            results, column_info = _analyze_SelectStmt(
-                node,
-                self.database,
-                self.cache,
-                self.fts_fields,
-                self.embedding_server_address,
-                self.select_username,
-                self.select_userpswd,
-                self.table_w_ids,
-                self.llm_model_name,
-                self.max_verify,
-                self.api_base,
-                self.api_version,
-                self.api_key,
-                disable_retriever=self.disable_retriever,
-                cte_column_lineage=self.cte_column_lineage,
-                enable_classifier=self.enable_classifier,
-            )
+            if freeTextFcnVisitor.res:
+                # main entry point for SUQL compiler optimization
+                results, column_info = _analyze_SelectStmt(
+                    node,
+                    self.database,
+                    self.cache,
+                    self.fts_fields,
+                    self.embedding_server_address,
+                    self.select_username,
+                    self.select_userpswd,
+                    self.table_w_ids,
+                    self.llm_model_name,
+                    self.max_verify,
+                    self.api_base,
+                    self.api_version,
+                    self.api_key,
+                    disable_retriever=self.disable_retriever,
+                    cte_column_lineage=self.cte_column_lineage,
+                    enable_classifier=self.enable_classifier,
+                )
+            else:
+                # Nothing to retrieve on - the WHERE clause is purely
+                # structural. Run it as-is to get the rows the query will
+                # output, so the projection predicates can be verified per row.
+                results, column_info = _execute_structural_sql(
+                    node,
+                    self.database,
+                    node.whereClause,
+                    self.cache,
+                    self.fts_fields,
+                    self.select_username,
+                    self.select_userpswd,
+                    self.llm_model_name,
+                    self.api_base,
+                    self.api_version,
+                    self.api_key,
+                    self.host,
+                    self.port,
+                    enable_classifier=self.enable_classifier,
+                    preserve_limit=_if_limit_pushdown_safe(node),
+                )
+
+            if has_projection_predicates:
+                # Re-extract now that _execute_structural_sql has had its chance
+                # to rewrite join column references, and replace each comparison
+                # with the boolean column it is about to be materialized under.
+                projection_predicates = _extract_projection_predicates(
+                    node, replace=True
+                )
+                results, column_info = _verify_projection_predicates(
+                    node,
+                    projection_predicates,
+                    results,
+                    column_info,
+                    self.llm_model_name,
+                    self.api_base,
+                    self.api_version,
+                    self.api_key,
+                    max_workers=self.max_verification_workers,
+                )
 
             # computed text expressions given to answer() are projected under
             # internal aliases (issue #50) - they have served their purpose by
             # now and must not leak into the temp table or the user's results
             results, column_info = _drop_internal_columns(results, column_info)
+
+            if has_projection_predicates:
+                _expand_star_targets(node, column_info)
 
             # based on results and column_info, insert a temporary table
             column_create_stmt = ",\n".join(
@@ -1230,7 +1595,9 @@ def _verify_single_res(
     return all_found
 
 
-def _parallel_filtering(fcn, source: list, limit, enforce_ordering=False):
+def _parallel_filtering(
+    fcn, source: list, limit, enforce_ordering=False, max_workers=None
+):
     true_count = 0
     true_items = set()
 
@@ -1238,7 +1605,9 @@ def _parallel_filtering(fcn, source: list, limit, enforce_ordering=False):
     # which indicates whether an item has been verified
     ordered_results = {i: None for i in range(len(source))}
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=_resolve_max_workers(max_workers)
+    ) as executor:
         futures = {
             executor.submit(contextvars.copy_context().run, fcn, item): item
             for item in source
@@ -1277,6 +1646,147 @@ def _parallel_filtering(fcn, source: list, limit, enforce_ordering=False):
         return res
 
     return true_items
+
+
+def _resolve_projection_text_source(text_arg, node: SelectStmt, single_table, column_names):
+    """Where in the structural query's rows the text argument of a projection
+    predicate can be read from. Returns `(field, column_index)`, where `field`
+    is the usual `(table, column)` tuple or a `_ComputedTextField`."""
+    if isinstance(text_arg, ColumnRef):
+        parts = tuple(x.sval for x in text_arg.fields if isinstance(x, String))
+        if len(parts) != len(text_arg.fields):
+            raise ValueError(
+                "the text argument of a free text function must name a column "
+                "or be a text expression, but is a wildcard: {}".format(
+                    RawStream()(text_arg)
+                )
+            )
+        if single_table:
+            table = node.fromClause[0].relname
+            column = parts[-1]
+            target = column
+        elif len(parts) == 2:
+            table, column = parts
+            target = "{}^{}".format(table, column)
+        else:
+            # Either a join whose column refs _Replace_Original_Target_Visitor
+            # already flattened to "table^column", or a FROM shape that projects
+            # the column under its own name (e.g. a subquery).
+            target = parts[0]
+            if target not in column_names:
+                matches = [c for c in column_names if c.endswith("^" + target)]
+                if len(matches) != 1:
+                    raise ValueError(
+                        "cannot tell which table the text argument {} belongs "
+                        "to; qualify it with a table name".format(target)
+                    )
+                target = matches[0]
+            table, _, column = target.partition("^")
+            if not column:
+                table, column = "", target
+        field = (table, column)
+    else:
+        if not single_table:
+            raise NotImplementedError(
+                "a computed text expression given to answer() outside the WHERE "
+                "clause is only supported for single-table queries; got: "
+                "{}".format(RawStream()(text_arg))
+            )
+        expr_sql = RawStream()(text_arg)
+        target = _computed_text_alias(expr_sql)
+        field = _ComputedTextField(
+            table=node.fromClause[0].relname,
+            column=target,
+            expr_sql=expr_sql,
+        )
+
+    if target not in column_names:
+        raise ValueError(
+            "the structural query did not project {}, needed to verify "
+            "answer({}, ...)".format(target, RawStream()(text_arg))
+        )
+    return field, column_names.index(target)
+
+
+def _verify_projection_predicates(
+    node: SelectStmt,
+    projection_predicates,
+    results,
+    column_info,
+    llm_model_name,
+    api_base=None,
+    api_version=None,
+    api_key=None,
+    max_workers=None,
+):
+    """Evaluates free text comparisons that sit outside the WHERE clause, and
+    appends one synthetic boolean column per comparison to the structural
+    results.
+
+    A WHERE predicate gets to prune, so it can be answered from the top-k the
+    retriever returns. A projection cannot: the query has to emit a value for
+    every row it outputs, and a row the retriever happens to miss would silently
+    become a false negative in the user's aggregate. So there is no retrieval
+    step here - every surviving row is verified.
+
+    That makes this rows x predicates LLM calls, all mutually independent, which
+    is the easy case for concurrency: they go into one flat pool rather than
+    being nested per row (`_verify_single_res` short-circuits on the first false
+    predicate, which is right for a filter and wrong here, since every
+    predicate's value is needed regardless).
+    """
+    single_table = len(node.fromClause) == 1 and isinstance(
+        node.fromClause[0], RangeVar
+    )
+    column_names = [x[0] for x in column_info]
+
+    plan = []
+    for alias, (text_arg, query, operator, value) in sorted(
+        projection_predicates.items()
+    ):
+        field, column_index = _resolve_projection_text_source(
+            text_arg, node, single_table, column_names
+        )
+        plan.append((alias, column_index, field, query, operator, value))
+
+    tasks = [(row, entry) for row in results for entry in plan]
+
+    def verify_one(task):
+        row, (_, column_index, field, query, operator, value) = task
+        document = row[column_index]
+        # NULL text can never satisfy the predicate
+        if document is None:
+            return False
+        if not isinstance(document, str):
+            document = str(document)
+        return _verify(
+            document,
+            field,
+            query,
+            operator,
+            value,
+            llm_model_name,
+            api_base,
+            api_version,
+            api_key,
+        )
+
+    start_time = time.time()
+    verdicts = _parallel_map(verify_one, tasks, max_workers=max_workers)
+    logging.info(
+        "verified %d projection predicate value(s) over %d row(s) in %.2fs",
+        len(tasks),
+        len(results),
+        time.time() - start_time,
+    )
+
+    width = len(plan)
+    new_results = [
+        tuple(row) + tuple(verdicts[i * width : (i + 1) * width])
+        for i, row in enumerate(results)
+    ]
+    new_column_info = list(column_info) + [(entry[0], "boolean") for entry in plan]
+    return new_results, new_column_info
 
 
 # Upper bound on how many rows the compiler is willing to send to the LLM when
@@ -2155,8 +2665,13 @@ def _execute_structural_sql(
     host="127.0.0.1",
     port="5432",
     enable_classifier=False,
+    preserve_limit=False,
 ):
     _ = RawStream()(original_node)  # RawStream takes care of some issue, to investigate
+    # Collect these before the join branch below rewrites `t.col` references in
+    # the projection into the flat "t^col" form: the structural query has to
+    # evaluate the expression against the real tables, using the original names.
+    computed_text_args = _extract_compiler_evaluated_computed_text_args(original_node)
     node = deepcopy(original_node)
     # change projection to include everything
     # there are a couple of cases here
@@ -2274,15 +2789,18 @@ def _execute_structural_sql(
     # evaluates them once per row, and the LLM verification step can read the
     # resulting string off each row (see issue #50). These columns are internal
     # and get stripped before results are returned (_drop_internal_columns).
-    computed_text_args = _extract_computed_text_args(original_node.whereClause)
     node.targetList = tuple(node.targetList) + tuple(
         ResTarget(name=alias, val=deepcopy(expr))
         for alias, expr in sorted(computed_text_args.items())
     )
 
-    # reset all limits
-    node.limitCount = None
-    node.limitOffset = None
+    # reset all limits. `preserve_limit` is set when the caller only needs the
+    # rows the final query will actually output and nothing downstream can
+    # change which rows those are - a projection predicate filters nothing, so
+    # the LIMIT can be pushed down and bound the number of LLM calls.
+    if not preserve_limit:
+        node.limitCount = None
+        node.limitOffset = None
     # change predicates
     node.whereClause = predicate
     # reset other unecessary clauses
@@ -3042,6 +3560,7 @@ def suql_execute(
     debug_log=None,
     disable_retriever=False,
     enable_classifier=False,
+    max_verification_workers=None,
 ):
     """
     Main entry point to the SUQL Python-based compiler.
@@ -3104,6 +3623,11 @@ def suql_execute(
         column's distinct values. Useful for natural-language queries against enum-like columns.
         Defaults to False because the current implementation walks into CTE bodies / subqueries
         and emits spurious probe SQLs there (see issue #52). Set to True to opt in.
+
+    `max_verification_workers` (int, optional): How many verification LLM calls to keep in
+        flight. These are I/O-bound HTTP round trips, so the useful value tracks the provider's
+        rate limits rather than the local core count. Defaults to 32, overridable process-wide
+        with the `SUQL_MAX_VERIFICATION_WORKERS` environment variable.
 
     # Returns:
     `results` (List[[*]]): A list of returned database results. Each inner list stores a row of returned result.
@@ -3198,6 +3722,7 @@ def suql_execute(
             statement_timeout=statement_timeout,
             disable_retriever=disable_retriever,
             enable_classifier=enable_classifier,
+            max_verification_workers=max_verification_workers,
         )
     finally:
         _query_tracker.reset(token)
@@ -3261,6 +3786,7 @@ def _suql_execute_single(
     statement_timeout=30000,
     disable_retriever=False,
     enable_classifier=False,
+    max_verification_workers=None,
 ):
     results = []
     column_names = []
@@ -3285,6 +3811,7 @@ def _suql_execute_single(
             port=port,
             disable_retriever=disable_retriever,
             enable_classifier=enable_classifier,
+            max_verification_workers=max_verification_workers,
         )
         root = parse_sql(suql)
         visitor(root)

--- a/src/suql/sql_free_text_support/execute_free_text_sql.py
+++ b/src/suql/sql_free_text_support/execute_free_text_sql.py
@@ -439,6 +439,49 @@ def _expand_star_targets(node: SelectStmt, column_info):
         node.targetList = tuple(expanded)
 
 
+def _single_rangevar_relname(from_clause):
+    """The relname of `from_clause`, when it is exactly one plain table
+    reference; None otherwise."""
+    if (
+        from_clause
+        and len(from_clause) == 1
+        and isinstance(from_clause[0], RangeVar)
+    ):
+        return from_clause[0].relname
+    return None
+
+
+def _if_body_is_bare_select_star(body: SelectStmt):
+    """True when `body` is exactly `SELECT * FROM <one table>` - i.e. the table
+    it reads from already *is* the body's result, so downstream references can
+    be pointed straight at that table."""
+    target_list = body.targetList or ()
+    if len(target_list) != 1:
+        return False
+    target = target_list[0]
+    if not (
+        isinstance(target, ResTarget)
+        and isinstance(target.val, ColumnRef)
+        and len(target.val.fields) == 1
+        and isinstance(target.val.fields[0], A_Star)
+    ):
+        return False
+    if _single_rangevar_relname(body.fromClause) is None:
+        return False
+    return not any(
+        (
+            body.whereClause,
+            body.groupClause,
+            body.havingClause,
+            body.sortClause,
+            body.distinctClause,
+            body.limitCount,
+            body.limitOffset,
+            body.withClause,
+        )
+    )
+
+
 def _if_limit_pushdown_safe(node: SelectStmt):
     """Whether the query's LIMIT can be applied while fetching the rows that
     projection predicates will be verified against.
@@ -896,12 +939,21 @@ class _SelectVisitor(Visitor):
             # Alias the temp table back to that name so those references keep
             # resolving. Joins don't need this - _Replace_Original_Target_Visitor
             # already rewrote their references to the "table^column" form.
+            # A CTE body whose FROM was already swapped for an upstream temp
+            # table carries an alias naming the relation the rest of the body
+            # refers to (see _rewrite_cte_refs). _replace_table_aliases skips
+            # temp tables, so that alias is still the name in use and must be
+            # carried over; otherwise fall back to the real table's name, which
+            # is what _replace_table_aliases rewrote references to.
             original_from = node.fromClause
-            table_alias = (
-                Alias(aliasname=original_from[0].relname)
-                if len(original_from) == 1 and isinstance(original_from[0], RangeVar)
-                else None
-            )
+            table_alias = None
+            if len(original_from) == 1 and isinstance(original_from[0], RangeVar):
+                source = original_from[0]
+                table_alias = Alias(
+                    aliasname=source.alias.aliasname
+                    if source.alias is not None
+                    else source.relname
+                )
             node.fromClause = (
                 RangeVar(
                     relname=tmp_table_name,
@@ -975,6 +1027,16 @@ class _SelectVisitor(Visitor):
             # (its surrounding WITH lives on the OUTER SelectStmt).
             self._rewrite_cte_refs(cte.ctequery, cte_to_tmp)
 
+            # Do this before inferring the ID column. Only a CTE materialized
+            # as *input* to a later answer() needs the ID added: one that
+            # carries answer() itself is materialized by _execute_structural_sql,
+            # whose `SELECT *` already brings the ID across from its source.
+            # Restricting it this way also keeps the added column out of the
+            # answer()-bearing CTE's own projection, so `SELECT * FROM <cte>`
+            # still returns what the user asked for.
+            if name in needs_mat and not _if_contains_free_text_fcn(cte.ctequery):
+                self._augment_cte_projection_with_id(cte.ctequery)
+
             id_col = self._infer_cte_id_column(cte.ctequery)
             # Build column lineage from the (now rewritten) body. Composes
             # through self.cte_column_lineage for sources that are
@@ -985,6 +1047,12 @@ class _SelectVisitor(Visitor):
             self.cte_column_lineage[name] = lineage
 
             if name in needs_mat:
+                # What this body reads from *before* we try to materialize it.
+                # _rewrite_cte_refs may already have pointed it at an upstream
+                # CTE's temp table, which must not be mistaken for this CTE's
+                # own materialization below.
+                before = _single_rangevar_relname(cte.ctequery.fromClause)
+
                 if _if_contains_free_text_fcn(cte.ctequery):
                     # Body has answer(); the natural visit_SelectStmt path
                     # creates a temp table and rewrites the body in place.
@@ -996,11 +1064,29 @@ class _SelectVisitor(Visitor):
                     # `FROM <this_cte>` once we rewrite it.
                     self._materialize_cte_body_directly(cte.ctequery)
 
-                from_cls = cte.ctequery.fromClause
-                if (from_cls and len(from_cls) == 1
-                        and isinstance(from_cls[0], RangeVar)
-                        and from_cls[0].relname.startswith("temp_table_")):
-                    tmp_name = from_cls[0].relname
+                # Downstream references are redirected to a temp table only if
+                # that table holds this CTE's *output*. Two ways that fails:
+                #   - visit_SelectStmt returned without materializing (nothing
+                #     for the compiler to evaluate, e.g. a bare `answer(...)`
+                #     projection with no comparison), leaving `before` in place;
+                #   - it did materialize, but the body still carries a real
+                #     projection, so the temp table is that projection's *input*
+                #     and lacks the columns the body computes.
+                # Either way, redirecting downstream would drop those columns
+                # (`column "..." does not exist`). Materialize the body's own
+                # output instead.
+                after = _single_rangevar_relname(cte.ctequery.fromClause)
+                if (
+                    after is None
+                    or after == before
+                    or not after.startswith("temp_table_")
+                    or not _if_body_is_bare_select_star(cte.ctequery)
+                ):
+                    self._materialize_cte_body_directly(cte.ctequery)
+                    after = _single_rangevar_relname(cte.ctequery.fromClause)
+
+                if after is not None and after.startswith("temp_table_"):
+                    tmp_name = after
                     cte_to_tmp[name] = tmp_name
                     # Also register lineage under the temp table name so
                     # cross-CTE refs (which target the temp name after our
@@ -1091,7 +1177,16 @@ class _SelectVisitor(Visitor):
     @staticmethod
     def _rewrite_cte_refs(body, mapping):
         """Replace `RangeVar.relname` with `mapping[relname]` wherever the
-        relname is a key in `mapping`. In-place AST mutation."""
+        relname is a key in `mapping`. In-place AST mutation.
+
+        The name the surrounding query uses to refer to the relation is kept as
+        an alias. Without it, swapping `base` for `temp_table_xxx` orphans every
+        qualified reference in the same body - `SELECT base.event_id_cnty ...
+        FROM base` becomes `SELECT base.event_id_cnty ... FROM temp_table_xxx`,
+        which Postgres rejects with `missing FROM-clause entry for table
+        "base"`. An explicit alias (`FROM base b`) is already the name in use,
+        so it is left alone.
+        """
         if not mapping:
             return
 
@@ -1099,9 +1194,46 @@ class _SelectVisitor(Visitor):
             def visit_RangeVar(self, ancestors, node):
                 if (node.schemaname is None and node.catalogname is None
                         and node.relname in mapping):
+                    if node.alias is None:
+                        node.alias = Alias(aliasname=node.relname)
                     node.relname = mapping[node.relname]
 
         _Rewriter()(body)
+
+    def _augment_cte_projection_with_id(self, body):
+        """Add the source relation's ID column to a to-be-materialized CTE's
+        projection when the CTE drops it.
+
+        A materialized CTE becomes an ordinary table that the SUQL pipeline then
+        runs against, and that pipeline needs a row ID: `_retrieve_and_verify`
+        keys the retriever's `id_list` and its per-row dedup on it. A CTE like
+        `SELECT country, admin1, notes FROM events` throws the ID away, leaving
+        the temp table unregistrable in `table_w_ids` - which used to surface
+        downstream as a bare `KeyError: 'temp_table_xxx'`.
+
+        Only safe for a straight row-wise projection: with GROUP BY, DISTINCT or
+        an aggregate there is no row to identify, and the extra column would not
+        even be valid SQL. Those cases keep no ID and are reported by
+        `_retrieve_and_verify` instead.
+        """
+        rel = _single_rangevar_relname(body.fromClause)
+        if rel is None or rel not in self.table_w_ids:
+            return
+        if body.groupClause or body.distinctClause or body.havingClause:
+            return
+        target_list = body.targetList or ()
+        if _contains_aggregate(target_list):
+            return
+
+        id_col = self.table_w_ids[rel]
+        source = body.fromClause[0]
+        qualifier = source.alias.aliasname if source.alias is not None else rel
+        if self._projection_includes(target_list, qualifier, id_col):
+            return
+
+        body.targetList = tuple(target_list) + (
+            ResTarget(val=ColumnRef(fields=(String(sval=id_col),))),
+        )
 
     def _infer_cte_id_column(self, body):
         """Best-effort: figure out which row-ID column this CTE's temp table
@@ -1941,7 +2073,20 @@ def _retrieve_and_verify(
     )
 
     if len(node.fromClause) == 1 and isinstance(node.fromClause[0], RangeVar):
-        id_field_name = table_w_ids[node.fromClause[0].relname]
+        relname = node.fromClause[0].relname
+        if relname not in table_w_ids:
+            # A materialized CTE with no usable row ID - typically one that
+            # aggregates (GROUP BY / DISTINCT), so there is no row to identify.
+            # Used to escape as a bare `KeyError: 'temp_table_xxx'`.
+            raise NotImplementedError(
+                "answer() is applied to a relation with no known ID column: "
+                "{}. If this is a CTE, project the source table's ID column "
+                "in it (one of: {}) so rows can be identified for retrieval "
+                "and de-duplication.".format(
+                    relname, ", ".join(sorted(table_w_ids.values())) or "none known"
+                )
+            )
+        id_field_name = table_w_ids[relname]
         single_table = True
         id_index = list(map(lambda x: x[0], column_info)).index(id_field_name)
         id_list = list(map(lambda x: x[id_index], existing_results))

--- a/tests/test_cte_answer_regressions.py
+++ b/tests/test_cte_answer_regressions.py
@@ -1,0 +1,339 @@
+"""Regressions for CTE materialization around `answer()`.
+
+Four failure modes, all from one reported pipeline run in which 12/12 SUQL
+executions failed. Each is the same underlying mistake in a different place:
+a CTE is materialized into a temp table, and something the rest of the query
+needs is not carried across.
+
+  A  `missing FROM-clause entry for table "b"`
+     `FROM base b` ... `SELECT b.*`. Swapping `base` for `temp_table_xxx`
+     dropped the name the body refers to the relation by.
+
+  B  `missing FROM-clause entry for table "base"`
+     Same, for an unaliased `FROM base` with `base.<col>` references.
+
+  C  `KeyError: 'temp_table_xxx'`
+     A CTE that does not project the source table's ID column cannot be
+     registered in `table_w_ids`, so the pipeline could not identify its rows.
+
+  D  `column "russian_yes" does not exist`
+     Downstream references were redirected to a temp table that holds the CTE's
+     *input* rather than its output, dropping every column the body computes.
+
+Integration checks run against the live Postgres `acled` DB with only the LLM
+verification call stubbed out, so the CTE machinery, temp tables and rewritten
+SQL are all real.
+"""
+
+import os
+import sys
+import traceback
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
+
+from pglast import parse_sql
+from pglast.ast import Alias, RangeVar
+from pglast.stream import RawStream
+
+import suql.sql_free_text_support.execute_free_text_sql as suql_module
+from suql.sql_free_text_support.execute_free_text_sql import (
+    _SelectVisitor,
+    _if_body_is_bare_select_star,
+    _single_rangevar_relname,
+    suql_execute,
+)
+
+QUESTION = "Is this an attack on energy infrastructure?"
+POSITIVE_IDS = ["UKR73236", "UKR69217", "UKR88237"]
+NEGATIVE_IDS = ["UKR127789", "UKR73096"]
+ALL_IDS = POSITIVE_IDS + NEGATIVE_IDS
+ID_LITERALS = ", ".join("'{}'".format(i) for i in ALL_IDS)
+
+
+def _stmt(sql):
+    return parse_sql(sql)[0].stmt
+
+
+# ---------- unit checks -------------------------------------------------------
+
+def check_rewrite_cte_refs_keeps_the_referenced_name():
+    """`FROM base` must become `FROM temp_table_x AS base`, or every
+    `base.<col>` in the same body dangles."""
+    body = _stmt("SELECT base.a, base.b FROM base")
+    _SelectVisitor._rewrite_cte_refs(body, {"base": "temp_table_x"})
+    out = RawStream()(body)
+    assert "temp_table_x AS base" in out, out
+    assert _single_rangevar_relname(body.fromClause) == "temp_table_x"
+
+
+def check_rewrite_cte_refs_preserves_an_explicit_alias():
+    """An explicit alias is already the name in use - keep it, don't replace
+    it with the CTE name."""
+    body = _stmt("SELECT b.* FROM base b")
+    _SelectVisitor._rewrite_cte_refs(body, {"base": "temp_table_x"})
+    out = RawStream()(body)
+    assert "temp_table_x AS b" in out, out
+    assert " AS base" not in out, out
+
+
+def check_rewrite_cte_refs_leaves_unmapped_tables_alone():
+    body = _stmt("SELECT * FROM events")
+    _SelectVisitor._rewrite_cte_refs(body, {"base": "temp_table_x"})
+    assert RawStream()(body) == "SELECT * FROM events", RawStream()(body)
+
+
+def check_bare_select_star_detection():
+    """A temp table can stand in for a CTE only when the body adds nothing."""
+    assert _if_body_is_bare_select_star(_stmt("SELECT * FROM temp_table_x"))
+    for sql in (
+        "SELECT a, b FROM temp_table_x",
+        "SELECT * FROM temp_table_x WHERE a > 1",
+        "SELECT * FROM temp_table_x GROUP BY a",
+        "SELECT DISTINCT * FROM temp_table_x",
+        "SELECT * FROM temp_table_x LIMIT 5",
+        "SELECT * FROM a JOIN b ON a.i = b.i",
+        "SELECT *, 1 AS extra FROM temp_table_x",
+    ):
+        assert not _if_body_is_bare_select_star(_stmt(sql)), sql
+
+
+def check_single_rangevar_relname():
+    assert _single_rangevar_relname(_stmt("SELECT * FROM t").fromClause) == "t"
+    assert _single_rangevar_relname(_stmt("SELECT 1").fromClause) is None
+    assert _single_rangevar_relname(
+        _stmt("SELECT * FROM a, b").fromClause
+    ) is None
+    assert _single_rangevar_relname(
+        _stmt("SELECT * FROM a JOIN b ON a.i = b.i").fromClause
+    ) is None
+
+
+UNIT_CHECKS = [
+    check_rewrite_cte_refs_keeps_the_referenced_name,
+    check_rewrite_cte_refs_preserves_an_explicit_alias,
+    check_rewrite_cte_refs_leaves_unmapped_tables_alone,
+    check_bare_select_star_detection,
+    check_single_rangevar_relname,
+]
+
+
+# ---------- integration -------------------------------------------------------
+
+class _StubbedVerification:
+    def __init__(self):
+        self.calls = 0
+        self._original = None
+
+    def __enter__(self):
+        self._original = suql_module._verify
+        suql_module._verified_res = {}
+
+        def _fake_verify(document, field, query, operator, value, *a, **k):
+            self.calls += 1
+            text = (document or "").lower()
+            return "power station" in text or "pipeline" in text
+
+        suql_module._verify = _fake_verify
+        return self
+
+    def __exit__(self, *exc):
+        suql_module._verify = self._original
+        return False
+
+
+def _run(sql, **overrides):
+    kwargs = dict(
+        table_w_ids={"events": "event_id_cnty"},
+        database="acled",
+        select_username="select_user",
+        select_userpswd="select_user",
+        host="127.0.0.1",
+        port="5432",
+        embedding_server_address=os.environ.get(
+            "SUQL_EMBEDDING_SERVER", "http://127.0.0.1:8505"
+        ),
+        llm_model_name="gpt-4o-mini",
+        disable_try_catch=True,
+        statement_timeout=300000,
+    )
+    kwargs.update(overrides)
+    return suql_execute(sql, **kwargs)
+
+
+_EXPECTED_FLAGS = [(i, 1 if i in POSITIVE_IDS else 0) for i in sorted(ALL_IDS)]
+
+
+def check_group_a_cte_alias_and_star():
+    """`FROM base b` + `SELECT b.*`."""
+    sql = """
+    WITH base AS (
+      SELECT event_id_cnty, country, notes FROM events WHERE event_id_cnty IN ({ids})
+    ), classified AS (
+      SELECT b.*, CASE WHEN answer(b.notes, '{q}') = 'Yes' THEN 1 ELSE 0 END AS flag
+      FROM base b
+    )
+    SELECT event_id_cnty, flag FROM classified ORDER BY event_id_cnty
+    """.format(ids=ID_LITERALS, q=QUESTION)
+    with _StubbedVerification():
+        rows, columns, _ = _run(sql)
+    assert columns == ["event_id_cnty", "flag"], columns
+    assert rows == _EXPECTED_FLAGS, rows
+
+
+def check_group_b_cte_referenced_by_name():
+    """`FROM base` + `base.<col>`."""
+    sql = """
+    WITH base AS (
+      SELECT event_id_cnty, country, notes FROM events WHERE event_id_cnty IN ({ids})
+    ), classified AS (
+      SELECT base.event_id_cnty, base.country,
+             CASE WHEN answer(base.notes, '{q}') = 'Yes' THEN 1 ELSE 0 END AS flag
+      FROM base
+    )
+    SELECT event_id_cnty, flag FROM classified ORDER BY event_id_cnty
+    """.format(ids=ID_LITERALS, q=QUESTION)
+    with _StubbedVerification():
+        rows, columns, _ = _run(sql)
+    assert columns == ["event_id_cnty", "flag"], columns
+    assert rows == _EXPECTED_FLAGS, rows
+
+
+def check_group_c_cte_drops_the_id_column():
+    """The CTE never projects `event_id_cnty`; the compiler must add it back
+    rather than failing to register the temp table."""
+    sql = """
+    WITH base AS (
+      SELECT country, admin1, notes FROM events WHERE event_id_cnty IN ({ids})
+    ), hits AS (
+      SELECT * FROM base WHERE answer(notes, '{q}') = 'Yes'
+    )
+    SELECT country, COUNT(*) AS n FROM hits GROUP BY country
+    """.format(ids=ID_LITERALS, q=QUESTION)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert rows == [("Ukraine", len(POSITIVE_IDS))], rows
+
+
+def check_group_c_does_not_leak_the_id_into_results():
+    """Adding the ID back is internal - it must not change what the user's
+    own projection returns."""
+    sql = """
+    WITH base AS (
+      SELECT country, admin1, notes FROM events WHERE event_id_cnty IN ({ids})
+    ), hits AS (
+      SELECT country, admin1 FROM base WHERE answer(notes, '{q}') = 'Yes'
+    )
+    SELECT * FROM hits ORDER BY admin1
+    """.format(ids=ID_LITERALS, q=QUESTION)
+    with _StubbedVerification():
+        rows, columns, _ = _run(sql)
+    assert columns == ["country", "admin1"], columns
+    assert len(rows) == len(POSITIVE_IDS), rows
+
+
+def check_group_d_derived_column_survives_materialization():
+    """A column the CTE computes must be visible to the next CTE."""
+    sql = """
+    WITH base AS (
+      SELECT event_id_cnty, country, notes FROM events WHERE event_id_cnty IN ({ids})
+    ), validated AS (
+      SELECT event_id_cnty, country,
+             CASE WHEN TRUE THEN answer(notes, '{q}') = 'Yes' END AS is_energy
+      FROM base
+    ), tall AS (
+      SELECT country, COUNT(*) FILTER (WHERE is_energy) AS n_yes, COUNT(*) AS n_total
+      FROM validated GROUP BY country
+    )
+    SELECT country, n_yes, n_total FROM tall
+    """.format(ids=ID_LITERALS, q=QUESTION)
+    with _StubbedVerification():
+        rows, columns, _ = _run(sql)
+    assert columns == ["country", "n_yes", "n_total"], columns
+    assert rows == [("Ukraine", len(POSITIVE_IDS), len(ALL_IDS))], rows
+
+
+def check_aggregating_cte_reports_clearly():
+    """A CTE that aggregates has no row to identify. That cannot be fixed by
+    projecting an ID, so it must produce an actionable error rather than a bare
+    KeyError on an internal table name."""
+    # `notes` is grouped by, not computed, so it keeps a traceable lineage to
+    # events.notes - which isolates the missing-ID failure from the separate
+    # (already actionable) "no traceable lineage" one.
+    sql = """
+    WITH per_country AS (
+      SELECT country, notes
+      FROM events WHERE event_id_cnty IN ({ids}) GROUP BY country, notes
+    ), hits AS (
+      SELECT * FROM per_country WHERE answer(notes, '{q}') = 'Yes'
+    )
+    SELECT country FROM hits
+    """.format(ids=ID_LITERALS, q=QUESTION)
+    with _StubbedVerification():
+        try:
+            _run(sql)
+        except NotImplementedError as e:
+            assert "no known ID column" in str(e), str(e)
+            return
+        except KeyError as e:
+            raise AssertionError("bare KeyError leaked: {}".format(e))
+    raise AssertionError("expected NotImplementedError")
+
+
+def check_plain_cte_pipeline_still_works():
+    """The shapes #45 added must be unaffected."""
+    sql = """
+    WITH base AS (
+      SELECT * FROM events WHERE event_id_cnty IN ({ids})
+    )
+    SELECT event_id_cnty FROM base WHERE answer(notes, '{q}') = 'Yes'
+    ORDER BY event_id_cnty
+    """.format(ids=ID_LITERALS, q=QUESTION)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert sorted(r[0] for r in rows) == sorted(POSITIVE_IDS), rows
+
+
+INTEGRATION_CHECKS = [
+    check_group_a_cte_alias_and_star,
+    check_group_b_cte_referenced_by_name,
+    check_group_c_cte_drops_the_id_column,
+    check_group_c_does_not_leak_the_id_into_results,
+    check_group_d_derived_column_survives_materialization,
+    check_aggregating_cte_reports_clearly,
+    check_plain_cte_pipeline_still_works,
+]
+
+
+# ---------- runner ------------------------------------------------------------
+
+def main():
+    failures = []
+    print("--- unit ---")
+    for check in UNIT_CHECKS:
+        try:
+            check()
+            print("[PASS] {}".format(check.__name__))
+        except Exception:
+            print("[FAIL] {}".format(check.__name__))
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    print("\n--- integration (real acled DB, stubbed LLM) ---")
+    for check in INTEGRATION_CHECKS:
+        try:
+            check()
+            print("[PASS] {}".format(check.__name__))
+        except Exception:
+            print("[FAIL] {}".format(check.__name__))
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    if failures:
+        print("\n{} failed: {}".format(len(failures), failures))
+        sys.exit(1)
+    print("\nall checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_projection_answer.py
+++ b/tests/test_projection_answer.py
@@ -1,0 +1,579 @@
+"""Tests for `answer()` comparisons outside the WHERE clause.
+
+`WHERE answer(notes, q) = 'Yes'` is compiled: the comparison goes to the
+verification prompt, which asks the LLM whether 'Yes' is a correct answer to
+`q` for that document. The same comparison in the SELECT list was not compiled
+at all - Postgres ran the raw plpython3u UDF, whose prompt is open-ended
+("Answer a question based on the following text"), and then string-compared its
+free-form prose against the literal. `Yes. The Zaporizhzhia Nuclear Power
+Station is part of energy infrastructure.` != `'Yes'`, so
+`CASE WHEN answer(...) = 'Yes' THEN 1 ELSE 0 END` returned 0 for rows the model
+had answered correctly, silently under-counting aggregates. Because
+`prompt_continuation` forces `temperature=1` for the gpt-5 family, the prose
+also varied run to run.
+
+The compiler now recognises `answer(...) <op> <literal>` in the projection,
+HAVING, GROUP BY and ORDER BY, verifies it per row through the same path a WHERE
+predicate takes, and materializes the result as a synthetic boolean column.
+
+Unit tests check the AST-level helpers in isolation.
+
+Integration tests run the full pipeline against the live Postgres `acled` DB,
+with only the LLM verification call stubbed out - so the structural SQL, the
+temp table, the rewritten query and the documents that would be handed to the
+LLM are all real.
+"""
+
+import os
+import sys
+import threading
+import time
+import traceback
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
+
+from pglast import parse_sql
+from pglast.stream import RawStream
+
+import suql.sql_free_text_support.execute_free_text_sql as suql_module
+from suql.sql_free_text_support.execute_free_text_sql import (
+    _INTERNAL_PRED_COLUMN_PREFIX,
+    _contains_aggregate,
+    _expand_star_targets,
+    _extract_projection_predicates,
+    _if_limit_pushdown_safe,
+    _if_projection_predicate,
+    _parallel_map,
+    _projection_predicate_alias,
+    _resolve_max_workers,
+    suql_execute,
+)
+
+QUESTION = "Is this an attack on energy infrastructure?"
+
+# Hand-labelled rows from the acled `events` table: three attacks on energy
+# infrastructure and three that are not. The stub below accepts on the keyword
+# "power station" / "pipeline", matching the first three.
+POSITIVE_IDS = ["UKR73236", "UKR69217", "UKR88237"]
+NEGATIVE_IDS = ["UKR127789", "UKR73096"]
+ALL_IDS = POSITIVE_IDS + NEGATIVE_IDS
+ID_LITERALS = ", ".join("'{}'".format(i) for i in ALL_IDS)
+
+
+def _stmt(sql):
+    return parse_sql(sql)[0].stmt
+
+
+def _first_target_expr(sql):
+    return _stmt(sql).targetList[0].val
+
+
+# ---------- unit checks -------------------------------------------------------
+
+def check_detects_bare_boolean_projection():
+    expr = _first_target_expr(
+        "SELECT answer(notes, '{}') = 'Yes' FROM events".format(QUESTION)
+    )
+    assert _if_projection_predicate(expr)
+
+
+def check_detects_case_when_and_aggregate_wrappers():
+    for sql in (
+        "SELECT CASE WHEN answer(notes, 'q') = 'Yes' THEN 1 ELSE 0 END FROM events",
+        "SELECT SUM(CASE WHEN answer(notes, 'q') = 'Yes' THEN 1 ELSE 0 END) FROM events",
+        "SELECT COUNT(*) FILTER (WHERE answer(notes, 'q') = 'Yes') FROM events",
+        "SELECT a FROM events GROUP BY a HAVING bool_or(answer(notes, 'q') = 'Yes')",
+        "SELECT a FROM events ORDER BY answer(notes, 'q') = 'Yes' DESC",
+    ):
+        assert len(_extract_projection_predicates(_stmt(sql))) == 1, sql
+
+
+def check_ignores_non_predicate_uses():
+    """A projection that wants the model's prose, or a comparison the
+    verification prompt cannot represent, must be left for Postgres."""
+    for sql in (
+        # the prose is the point
+        "SELECT answer(notes, 'which city?') FROM events",
+        # the WHERE pipeline owns this one
+        "SELECT event_id_cnty FROM events WHERE answer(notes, 'q') = 'Yes'",
+        # RHS is not a literal, so there is no candidate answer to verify
+        "SELECT answer(notes, 'q') = other_col FROM events",
+        # the call is wrapped, so replacing it with a boolean would not typecheck
+        "SELECT lower(answer(notes, 'q')) = 'yes' FROM events",
+        # not a free text function at all
+        "SELECT string_agg(notes, ' ') = 'x' FROM events",
+        # a nested SelectStmt owns its own projection
+        "SELECT (SELECT answer(notes, 'q') = 'Yes' FROM events LIMIT 1) FROM events",
+    ):
+        assert not _extract_projection_predicates(_stmt(sql)), sql
+
+
+def check_identical_comparisons_share_one_column():
+    """The same comparison written twice must be verified once."""
+    sql = (
+        "SELECT answer(notes, 'q') = 'Yes' AS a, "
+        "CASE WHEN answer(notes, 'q') = 'Yes' THEN 1 END AS b FROM events"
+    )
+    preds = _extract_projection_predicates(_stmt(sql))
+    assert len(preds) == 1, preds
+    alias = next(iter(preds))
+    assert alias.startswith(_INTERNAL_PRED_COLUMN_PREFIX), alias
+
+
+def check_alias_is_deterministic():
+    a = _projection_predicate_alias("answer(notes, 'q') = 'Yes'")
+    b = _projection_predicate_alias("answer(notes, 'q') = 'Yes'")
+    c = _projection_predicate_alias("answer(notes, 'q') = 'No'")
+    assert a == b and a != c
+
+
+def check_extraction_does_not_mutate_unless_asked():
+    node = _stmt("SELECT CASE WHEN answer(notes,'q')='Yes' THEN 1 END FROM events")
+    before = RawStream()(node)
+    _extract_projection_predicates(node)
+    assert RawStream()(node) == before
+
+
+def check_replacement_removes_the_udf_call():
+    node = _stmt(
+        "SELECT SUM(CASE WHEN answer(notes,'q')='Yes' THEN 1 ELSE 0 END) "
+        "FROM events WHERE country = 'Ukraine'"
+    )
+    preds = _extract_projection_predicates(node, replace=True)
+    out = RawStream()(node)
+    assert "answer(" not in out.lower(), out
+    assert all(alias in out for alias in preds), out
+    # the WHERE clause is untouched - it has its own pipeline
+    assert "country = 'Ukraine'" in out, out
+
+
+def check_aggregate_text_argument_is_refused():
+    node = _stmt(
+        "SELECT a FROM events GROUP BY a "
+        "HAVING answer(string_agg(notes, ' '), 'q') = 'Yes'"
+    )
+    try:
+        _extract_projection_predicates(node)
+    except NotImplementedError:
+        return
+    raise AssertionError("expected NotImplementedError")
+
+
+def check_contains_aggregate():
+    assert _contains_aggregate(_first_target_expr("SELECT sum(x) FROM t"))
+    assert _contains_aggregate(_first_target_expr("SELECT count(*) FROM t"))
+    assert _contains_aggregate(_first_target_expr("SELECT string_agg(a, ',') FROM t"))
+    assert not _contains_aggregate(_first_target_expr("SELECT lower(a) FROM t"))
+    assert not _contains_aggregate(_first_target_expr("SELECT COALESCE(a, '') FROM t"))
+
+
+def check_limit_pushdown_safety():
+    """A projection predicate filters nothing, so a LIMIT can be applied before
+    verification - unless something downstream reorders or regroups first."""
+    cases = [
+        ("SELECT a FROM t LIMIT 5", True),
+        ("SELECT a FROM t", False),
+        ("SELECT a FROM t ORDER BY a LIMIT 5", False),
+        ("SELECT a FROM t GROUP BY a LIMIT 5", False),
+        ("SELECT DISTINCT a FROM t LIMIT 5", False),
+        # the rewritten query would apply the OFFSET a second time
+        ("SELECT a FROM t LIMIT 5 OFFSET 10", False),
+    ]
+    for sql, want in cases:
+        assert _if_limit_pushdown_safe(_stmt(sql)) == want, sql
+
+
+def check_star_is_expanded_so_internals_do_not_leak():
+    node = _stmt("SELECT *, answer(notes,'q')='Yes' AS f FROM events")
+    _extract_projection_predicates(node, replace=True)
+    _expand_star_targets(
+        node,
+        [("event_id_cnty", "text"), ("notes", "text"), ("_suql_pred_dead", "boolean")],
+    )
+    out = RawStream()(node)
+    assert "*" not in out, out
+    assert "event_id_cnty" in out and "notes" in out, out
+    assert out.count(_INTERNAL_PRED_COLUMN_PREFIX) == 1, out
+
+
+def check_max_workers_resolution():
+    assert _resolve_max_workers(8) == 8
+    assert _resolve_max_workers() == 32
+    os.environ["SUQL_MAX_VERIFICATION_WORKERS"] = "7"
+    try:
+        assert _resolve_max_workers() == 7
+        assert _resolve_max_workers(3) == 3, "explicit argument wins over env"
+    finally:
+        os.environ.pop("SUQL_MAX_VERIFICATION_WORKERS")
+
+
+def check_parallel_map_preserves_order_with_duplicates():
+    got = _parallel_map(lambda x: x * 2, [3, 1, 3, 2, 3], max_workers=4)
+    assert got == [6, 2, 6, 4, 6], got
+    assert _parallel_map(lambda x: x, []) == []
+
+
+UNIT_CHECKS = [
+    check_detects_bare_boolean_projection,
+    check_detects_case_when_and_aggregate_wrappers,
+    check_ignores_non_predicate_uses,
+    check_identical_comparisons_share_one_column,
+    check_alias_is_deterministic,
+    check_extraction_does_not_mutate_unless_asked,
+    check_replacement_removes_the_udf_call,
+    check_aggregate_text_argument_is_refused,
+    check_contains_aggregate,
+    check_limit_pushdown_safety,
+    check_star_is_expanded_so_internals_do_not_leak,
+    check_max_workers_resolution,
+    check_parallel_map_preserves_order_with_duplicates,
+]
+
+
+# ---------- integration -------------------------------------------------------
+
+class _StubbedVerification:
+    """Replaces the LLM verification call with a deterministic keyword match,
+    recording the concurrency it was driven at. Everything else - the structural
+    SQL, the temp table, the rewritten query - stays real."""
+
+    def __init__(self, accept=("power station", "pipeline"), delay=0.0):
+        self.accept = accept
+        self.delay = delay
+        self.seen = []
+        self.max_inflight = 0
+        self._inflight = 0
+        self._lock = threading.Lock()
+        self._original = None
+
+    def __enter__(self):
+        self._original = suql_module._verify
+        # the memo cache would hide repeated calls from this stub
+        suql_module._verified_res = {}
+
+        def _fake_verify(document, field, query, operator, value, *args, **kwargs):
+            with self._lock:
+                self.seen.append((document, field, query, operator, value))
+                self._inflight += 1
+                self.max_inflight = max(self.max_inflight, self._inflight)
+            if self.delay:
+                time.sleep(self.delay)
+            with self._lock:
+                self._inflight -= 1
+            text = (document or "").lower()
+            return any(k in text for k in self.accept)
+
+        suql_module._verify = _fake_verify
+        return self
+
+    def __exit__(self, *exc):
+        suql_module._verify = self._original
+        return False
+
+
+def _run(sql, **overrides):
+    kwargs = dict(
+        table_w_ids={"events": "event_id_cnty"},
+        database="acled",
+        select_username="select_user",
+        select_userpswd="select_user",
+        host="127.0.0.1",
+        port="5432",
+        embedding_server_address=os.environ.get(
+            "SUQL_EMBEDDING_SERVER", "http://127.0.0.1:8505"
+        ),
+        llm_model_name="gpt-4o-mini",
+        disable_try_catch=True,
+        statement_timeout=300000,
+    )
+    kwargs.update(overrides)
+    return suql_execute(sql, **kwargs)
+
+
+def check_reported_repro():
+    """The reported shape. Every row used to come back 0."""
+    sql = (
+        "SELECT event_id_cnty, "
+        "CASE WHEN answer(notes, '{}') = 'Yes' THEN 1 ELSE 0 END AS flag "
+        "FROM events WHERE event_id_cnty IN ({}) ORDER BY event_id_cnty"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification() as stub:
+        rows, columns, _ = _run(sql)
+
+    assert columns == ["event_id_cnty", "flag"], columns
+    got = dict(rows)
+    assert len(got) == len(ALL_IDS), got
+    for i in POSITIVE_IDS:
+        assert got[i] == 1, (i, got)
+    for i in NEGATIVE_IDS:
+        assert got[i] == 0, (i, got)
+    assert len(stub.seen) == len(ALL_IDS), stub.seen
+
+
+def check_verification_sees_the_question_and_the_literal():
+    """The comparison is what gets verified, not just the text: the question and
+    the compared-against value both have to reach the prompt."""
+    sql = (
+        "SELECT answer(notes, '{}') = 'Yes' AS f FROM events "
+        "WHERE event_id_cnty IN ({})"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification() as stub:
+        _run(sql)
+
+    assert stub.seen, "nothing reached verification"
+    for _, field, query, operator, value in stub.seen:
+        assert query == QUESTION, query
+        assert operator == "=", operator
+        assert value == "Yes", value
+        assert field == ("events", "notes"), field
+
+
+def check_aggregate_is_not_undercounted():
+    sql = (
+        "SELECT SUM(CASE WHEN answer(notes, '{}') = 'Yes' THEN 1 ELSE 0 END) AS n "
+        "FROM events WHERE event_id_cnty IN ({})"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert rows and rows[0][0] == len(POSITIVE_IDS), rows
+
+
+def check_projection_is_boolean_not_prose():
+    sql = (
+        "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f FROM events "
+        "WHERE event_id_cnty IN ({})"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert rows and all(isinstance(r[1], bool) for r in rows), rows
+
+
+def check_having_and_order_by():
+    with _StubbedVerification():
+        rows, _, _ = _run(
+            "SELECT country, COUNT(*) AS n FROM events WHERE event_id_cnty IN ({}) "
+            "GROUP BY country HAVING bool_or(answer(notes, '{}') = 'Yes')".format(
+                ID_LITERALS, QUESTION
+            )
+        )
+    assert len(rows) == 1 and rows[0][1] == len(ALL_IDS), rows
+
+    with _StubbedVerification():
+        rows, _, _ = _run(
+            "SELECT event_id_cnty FROM events WHERE event_id_cnty IN ({}) "
+            "ORDER BY answer(notes, '{}') = 'Yes' DESC, event_id_cnty".format(
+                ID_LITERALS, QUESTION
+            )
+        )
+    assert set(r[0] for r in rows[: len(POSITIVE_IDS)]) == set(POSITIVE_IDS), rows
+
+
+def check_internal_column_does_not_leak_into_select_star():
+    sql = (
+        "SELECT *, answer(notes, '{}') = 'Yes' AS f FROM events "
+        "WHERE event_id_cnty IN ({})"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        _, columns, _ = _run(sql)
+    assert not [c for c in columns if str(c).startswith("_suql_")], columns
+    assert "f" in columns, columns
+
+
+def check_two_questions_in_one_query():
+    """rows x predicates, all independent - both columns must be filled in."""
+    sql = (
+        "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS energy, "
+        "answer(notes, 'Did this happen in Ukraine?') = 'Yes' AS ukraine "
+        "FROM events WHERE event_id_cnty IN ({}) ORDER BY event_id_cnty"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification() as stub:
+        rows, columns, _ = _run(sql)
+    assert columns == ["event_id_cnty", "energy", "ukraine"], columns
+    assert len(stub.seen) == 2 * len(ALL_IDS), len(stub.seen)
+    questions = set(q for _, _, q, _, _ in stub.seen)
+    assert len(questions) == 2, questions
+
+
+def check_limit_is_pushed_down_on_an_unfiltered_query():
+    """Without pushdown this would verify every row of a 1.6M-row table."""
+    sql = "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f FROM events LIMIT 3".format(
+        QUESTION
+    )
+    with _StubbedVerification() as stub:
+        rows, _, _ = _run(sql)
+    assert len(rows) == 3, len(rows)
+    assert len(stub.seen) == 3, len(stub.seen)
+
+
+def check_limit_with_offset_still_returns_rows():
+    """The LIMIT may only be pushed down when the rewritten query re-applying it
+    is a no-op; with an OFFSET it is not."""
+    sql = (
+        "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f FROM events "
+        "WHERE country = 'Ukraine' AND year = 2022 LIMIT 3 OFFSET 5"
+    ).format(QUESTION)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert len(rows) == 3, len(rows)
+
+
+def check_column_projected_under_its_own_name_resolves():
+    """A FROM shape that is neither a single RangeVar nor a join still projects
+    the text column under its own name."""
+    sql = (
+        "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f "
+        "FROM (SELECT event_id_cnty, notes FROM events WHERE event_id_cnty IN ({})) sub"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    got = dict(rows)
+    assert len(got) == len(ALL_IDS), got
+    for i in POSITIVE_IDS:
+        assert got[i] is True, (i, got)
+    for i in NEGATIVE_IDS:
+        assert got[i] is False, (i, got)
+
+
+def check_computed_text_expression_in_a_projection():
+    """The issue #50 text-argument support, on the projection side."""
+    sql = (
+        "SELECT event_id_cnty, "
+        "answer(COALESCE(notes,'') || ' ' || COALESCE(tags,''), '{}') = 'Yes' AS f "
+        "FROM events WHERE event_id_cnty IN ({}) ORDER BY event_id_cnty"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification() as stub:
+        rows, _, _ = _run(sql)
+    got = dict(rows)
+    for i in POSITIVE_IDS:
+        assert got[i] is True, (i, got)
+    # the LLM must see the whole expression, not just `notes`
+    assert stub.seen and all(
+        isinstance(f, suql_module._ComputedTextField) for _, f, _, _, _ in stub.seen
+    ), stub.seen
+
+
+def check_free_text_where_plus_projection_predicate():
+    """Both stages run: the WHERE clause filters via the retriever, then the
+    surviving rows get their projection predicate verified."""
+    sql = (
+        "SELECT event_id_cnty, answer(notes, 'Did this happen in Ukraine?') = 'Yes' AS f "
+        "FROM events WHERE event_id_cnty IN ({}) AND answer(notes, '{}') = 'Yes'"
+    ).format(ID_LITERALS, QUESTION)
+    with _StubbedVerification():
+        rows, columns, _ = _run(sql)
+    assert columns == ["event_id_cnty", "f"], columns
+    assert sorted(r[0] for r in rows) == sorted(POSITIVE_IDS), rows
+
+
+def check_plain_projection_answer_is_left_to_postgres():
+    """A projection that wants prose must not be rewritten - the compiler has
+    nothing to verify there."""
+    node = _stmt(
+        "SELECT event_id_cnty, answer(notes, 'which city?') FROM events "
+        "WHERE country = 'Ukraine'"
+    )
+    assert not _extract_projection_predicates(node)
+
+
+def check_projection_predicate_inside_a_cte():
+    """CTE bodies go through the same visitor, so a predicate in one has to be
+    verified before the outer query filters on it."""
+    sql = (
+        "WITH flagged AS ("
+        "  SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f "
+        "  FROM events WHERE event_id_cnty IN ({})"
+        ") SELECT event_id_cnty FROM flagged WHERE f"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert sorted(r[0] for r in rows) == sorted(POSITIVE_IDS), rows
+
+
+def check_cte_predicate_feeding_an_outer_aggregate():
+    sql = (
+        "WITH flagged AS ("
+        "  SELECT country, CASE WHEN answer(notes, '{}') = 'Yes' THEN 1 ELSE 0 END AS f "
+        "  FROM events WHERE event_id_cnty IN ({})"
+        ") SELECT country, SUM(f) FROM flagged GROUP BY country"
+    ).format(QUESTION, ID_LITERALS)
+    with _StubbedVerification():
+        rows, _, _ = _run(sql)
+    assert rows == [("Ukraine", len(POSITIVE_IDS))], rows
+
+
+def check_max_verification_workers_is_honored():
+    sql = (
+        "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f FROM events "
+        "WHERE country = 'Ukraine' AND year = 2022 LIMIT 24"
+    ).format(QUESTION)
+
+    with _StubbedVerification(delay=0.2) as serial:
+        start = time.time()
+        rows, _, _ = _run(sql, max_verification_workers=1)
+        serial_elapsed = time.time() - start
+    assert len(rows) == 24, len(rows)
+    assert serial.max_inflight == 1, serial.max_inflight
+
+    with _StubbedVerification(delay=0.2) as parallel:
+        start = time.time()
+        rows, _, _ = _run(sql, max_verification_workers=12)
+        parallel_elapsed = time.time() - start
+    assert len(rows) == 24, len(rows)
+    assert parallel.max_inflight > 1, parallel.max_inflight
+    assert parallel.max_inflight <= 12, parallel.max_inflight
+    assert parallel_elapsed < serial_elapsed / 2, (parallel_elapsed, serial_elapsed)
+
+
+INTEGRATION_CHECKS = [
+    check_reported_repro,
+    check_verification_sees_the_question_and_the_literal,
+    check_aggregate_is_not_undercounted,
+    check_projection_is_boolean_not_prose,
+    check_having_and_order_by,
+    check_internal_column_does_not_leak_into_select_star,
+    check_two_questions_in_one_query,
+    check_limit_is_pushed_down_on_an_unfiltered_query,
+    check_limit_with_offset_still_returns_rows,
+    check_column_projected_under_its_own_name_resolves,
+    check_computed_text_expression_in_a_projection,
+    check_free_text_where_plus_projection_predicate,
+    check_plain_projection_answer_is_left_to_postgres,
+    check_projection_predicate_inside_a_cte,
+    check_cte_predicate_feeding_an_outer_aggregate,
+    check_max_verification_workers_is_honored,
+]
+
+
+# ---------- runner ------------------------------------------------------------
+
+def main():
+    failures = []
+    print("--- unit ---")
+    for check in UNIT_CHECKS:
+        try:
+            check()
+            print("[PASS] {}".format(check.__name__))
+        except Exception:
+            print("[FAIL] {}".format(check.__name__))
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    print("\n--- integration (real acled DB, stubbed LLM) ---")
+    for check in INTEGRATION_CHECKS:
+        try:
+            check()
+            print("[PASS] {}".format(check.__name__))
+        except Exception:
+            print("[FAIL] {}".format(check.__name__))
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    if failures:
+        print("\n{} failed: {}".format(len(failures), failures))
+        sys.exit(1)
+    print("\nall checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_verification_budget.py
+++ b/tests/test_verification_budget.py
@@ -1,0 +1,360 @@
+"""Tests for the per-query verification cost ceiling.
+
+Background: a reported pipeline run spent 25 hours and $101.51 on 4,326,211
+verification calls without a single query completing. The predicates were broad
+free-text questions over a large candidate set. Parallelism made that faster,
+not cheaper - nothing bounded the total.
+
+`suql_execute` now takes `max_verification_cost` (default $1.00). It is enforced
+in two places, and both matter:
+
+  - before every verification, so a query can never run past the ceiling;
+  - after a sample of calls, by extrapolating the mean over the remaining
+    planned verifications - so a query that would cost $100 is refused after
+    cents instead of after the full ceiling.
+
+These tests stub `llm_generate` rather than `_verify`, so the real `_verify`
+runs (including its budget check) and the tracker accumulates a known,
+deterministic cost per call.
+"""
+
+import os
+import sys
+import traceback
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "src"))
+
+import suql.sql_free_text_support.execute_free_text_sql as suql_module
+from suql.sql_free_text_support.execute_free_text_sql import (
+    _COST_PROJECTION_SAMPLE,
+    _VerificationBudget,
+    _resolve_verification_budget,
+    SUQLCostLimitExceeded,
+    suql_execute,
+)
+
+QUESTION = "Is this an attack on energy infrastructure?"
+
+
+class _FakeTracker(dict):
+    def __init__(self):
+        import threading
+
+        super().__init__(cost=0.0, calls=0, _lock=threading.Lock(), debug_log=None)
+
+
+# ---------- unit checks -------------------------------------------------------
+
+def check_defaults_and_overrides():
+    assert _resolve_verification_budget(None, None, None).max_cost == 1.0
+    assert _resolve_verification_budget(5.0, None, None).max_cost == 5.0
+    # 0 or negative removes the ceiling
+    assert _resolve_verification_budget(0, None, None).max_cost is None
+    assert _resolve_verification_budget(-1, None, None).max_cost is None
+
+    os.environ["SUQL_MAX_VERIFICATION_COST"] = "0.25"
+    os.environ["SUQL_MAX_VERIFICATION_CALLS"] = "40"
+    try:
+        b = _resolve_verification_budget(None, None, None)
+        assert b.max_cost == 0.25, b.max_cost
+        assert b.max_calls == 40, b.max_calls
+        # an explicit argument still wins over the environment
+        assert _resolve_verification_budget(2.0, None, None).max_cost == 2.0
+    finally:
+        os.environ.pop("SUQL_MAX_VERIFICATION_COST")
+        os.environ.pop("SUQL_MAX_VERIFICATION_CALLS")
+
+    os.environ["SUQL_MAX_VERIFICATION_COST"] = "not-a-number"
+    try:
+        assert _resolve_verification_budget(None, None, None).max_cost == 1.0
+    finally:
+        os.environ.pop("SUQL_MAX_VERIFICATION_COST")
+
+
+def check_ceiling_trips_on_accumulated_spend():
+    """With nothing planned there is no projection to go on, so the ceiling is
+    reached by accumulation. It must trip at the ceiling, not far past it."""
+    tracker = _FakeTracker()
+    budget = _VerificationBudget(max_cost=0.10, tracker=tracker)
+    n = 0
+    try:
+        for _ in range(1000):
+            budget.before_verification()
+            tracker["cost"] += 0.01
+            tracker["calls"] += 1
+            n += 1
+    except SUQLCostLimitExceeded as e:
+        assert "cost limit reached" in str(e), str(e)
+        # 10 calls covers the ceiling exactly; allow one more for float drift
+        assert 10 <= n <= 11, n
+        assert tracker["cost"] <= 0.11 + 1e-9, tracker["cost"]
+        return
+    raise AssertionError("expected SUQLCostLimitExceeded")
+
+
+def check_call_ceiling():
+    tracker = _FakeTracker()
+    budget = _VerificationBudget(max_cost=None, max_calls=5, tracker=tracker)
+    for _ in range(5):
+        budget.before_verification()
+        tracker["calls"] += 1
+    try:
+        budget.before_verification()
+    except SUQLCostLimitExceeded as e:
+        assert "call limit reached" in str(e), str(e)
+        return
+    raise AssertionError("expected SUQLCostLimitExceeded")
+
+
+def check_projection_refuses_before_spending_the_ceiling():
+    """The point of the whole exercise: a 4.3M-verification plan must be
+    refused after the sample, not after $1 of spend."""
+    tracker = _FakeTracker()
+    budget = _VerificationBudget(max_cost=1.00, tracker=tracker)
+    budget.register_planned(4_326_211)
+    per_call = 0.0000235  # ~= $101.51 / 4.3M, the reported rate
+    n = 0
+    try:
+        for _ in range(10_000):
+            budget.before_verification()
+            tracker["cost"] += per_call
+            tracker["calls"] += 1
+            n += 1
+    except SUQLCostLimitExceeded as e:
+        assert "projects to" in str(e), str(e)
+        assert "4,326,211" in str(e), str(e)
+        # refused right after the sample, having spent a fraction of a cent
+        assert n <= _COST_PROJECTION_SAMPLE + 1, n
+        assert tracker["cost"] < 0.01, tracker["cost"]
+        return
+    raise AssertionError("expected SUQLCostLimitExceeded")
+
+
+def check_projection_allows_an_affordable_plan():
+    tracker = _FakeTracker()
+    budget = _VerificationBudget(max_cost=1.00, tracker=tracker)
+    budget.register_planned(1000)
+    for _ in range(200):
+        budget.before_verification()          # 1000 * $0.0001 = $0.10, affordable
+        tracker["cost"] += 0.0001
+        tracker["calls"] += 1
+    assert tracker["cost"] < 1.0
+
+
+def check_no_ceiling_never_trips():
+    tracker = _FakeTracker()
+    budget = _VerificationBudget(max_cost=None, max_calls=None, tracker=tracker)
+    budget.register_planned(10_000_000)
+    for _ in range(100):
+        budget.before_verification()
+        tracker["cost"] += 1.0
+        tracker["calls"] += 1
+
+
+def check_cached_verifications_do_not_inflate_the_projection():
+    """Cost is projected per verification *attempt*, so documents served from
+    the memo cache (which cost nothing) don't make a cheap plan look expensive."""
+    tracker = _FakeTracker()
+    budget = _VerificationBudget(max_cost=1.00, tracker=tracker)
+    budget.register_planned(10_000)
+    # 1 real call in every 20 attempts; 10k attempts => 500 calls => $0.05
+    for i in range(2000):
+        budget.before_verification()
+        if i % 20 == 0:
+            tracker["cost"] += 0.0001
+            tracker["calls"] += 1
+    assert tracker["cost"] < 1.0
+
+
+UNIT_CHECKS = [
+    check_defaults_and_overrides,
+    check_ceiling_trips_on_accumulated_spend,
+    check_call_ceiling,
+    check_projection_refuses_before_spending_the_ceiling,
+    check_projection_allows_an_affordable_plan,
+    check_no_ceiling_never_trips,
+    check_cached_verifications_do_not_inflate_the_projection,
+]
+
+
+# ---------- integration -------------------------------------------------------
+
+COST_PER_CALL = 0.002
+
+
+class _MeteredLLM:
+    """Replaces `llm_generate` so the real `_verify` runs - budget check
+    included - while each call books a known cost against the query tracker."""
+
+    def __init__(self, cost_per_call=COST_PER_CALL, verdict="the answer is correct."):
+        self.cost_per_call = cost_per_call
+        self.verdict = verdict
+        self.calls = 0
+        self._original = None
+
+    def __enter__(self):
+        self._original = suql_module.llm_generate
+        suql_module._verified_res = {}
+
+        def _fake(*args, **kwargs):
+            tracker = suql_module._query_tracker.get()
+            if tracker is not None:
+                with tracker["_lock"]:
+                    tracker["cost"] += self.cost_per_call
+                    tracker["calls"] += 1
+            self.calls += 1
+            return [self.verdict]
+
+        suql_module.llm_generate = _fake
+        return self
+
+    def __exit__(self, *exc):
+        suql_module.llm_generate = self._original
+        return False
+
+
+def _run(sql, **overrides):
+    kwargs = dict(
+        table_w_ids={"events": "event_id_cnty"},
+        database="acled",
+        select_username="select_user",
+        select_userpswd="select_user",
+        host="127.0.0.1",
+        port="5432",
+        embedding_server_address=os.environ.get(
+            "SUQL_EMBEDDING_SERVER", "http://127.0.0.1:8505"
+        ),
+        llm_model_name="gpt-4o-mini",
+        disable_try_catch=True,
+        statement_timeout=300000,
+        free_text_server_address=None,
+    )
+    kwargs.update(overrides)
+    return suql_execute(sql, **kwargs)
+
+
+_BROAD = (
+    "SELECT event_id_cnty, answer(notes, '{}') = 'Yes' AS f FROM events "
+    "WHERE country = 'Ukraine' AND year = 2022 LIMIT 400"
+).format(QUESTION)
+
+
+def check_runaway_query_is_refused_cheaply():
+    """400 rows at $0.002 each would be $0.80; a $0.05 ceiling must stop it,
+    and the projection must stop it near the sample rather than at the ceiling."""
+    with _MeteredLLM() as llm:
+        try:
+            _run(_BROAD, max_verification_cost=0.05)
+        except SUQLCostLimitExceeded as e:
+            msg = str(e)
+            assert "max_verification_cost" in msg, msg
+            spent = llm.calls * COST_PER_CALL
+            assert spent <= 0.05 + COST_PER_CALL, (llm.calls, spent)
+            # the projection should fire around the sample size, well before
+            # the ceiling would have been reached by accumulation alone
+            assert llm.calls <= _COST_PROJECTION_SAMPLE + 2, llm.calls
+            return
+    raise AssertionError("expected SUQLCostLimitExceeded")
+
+
+def check_affordable_query_completes_and_reports_spend():
+    with _MeteredLLM(cost_per_call=0.00001) as llm:
+        rows, columns, cache = _run(_BROAD, max_verification_cost=1.0)
+    assert len(rows) == 400, len(rows)
+    assert columns == ["event_id_cnty", "f"], columns
+    stats = cache["_stats"]
+    assert stats["verifications"] == 400, stats
+    assert stats["max_verification_cost"] == 1.0, stats
+    assert 0 < stats["cost"] < 1.0, stats
+
+
+def check_ceiling_can_be_disabled():
+    with _MeteredLLM(cost_per_call=0.05) as llm:
+        rows, _, _ = _run(_BROAD, max_verification_cost=0)
+    assert len(rows) == 400, len(rows)
+    assert llm.calls == 400, llm.calls  # $20 spent, no ceiling to stop it
+
+
+def check_call_ceiling_applies_end_to_end():
+    with _MeteredLLM(cost_per_call=0.0) as llm:
+        try:
+            _run(_BROAD, max_verification_cost=0, max_verification_calls=30)
+        except SUQLCostLimitExceeded as e:
+            assert "call limit reached" in str(e), str(e)
+            assert llm.calls <= 31, llm.calls
+            return
+    raise AssertionError("expected SUQLCostLimitExceeded")
+
+
+def check_where_clause_verification_is_also_capped():
+    """The ceiling must cover the retriever-backed WHERE path, not just
+    projection predicates."""
+    sql = (
+        "SELECT event_id_cnty FROM events "
+        "WHERE country = 'Ukraine' AND year = 2022 AND answer(notes, '{}') = 'Yes'"
+    ).format(QUESTION)
+    with _MeteredLLM(cost_per_call=0.01) as llm:
+        try:
+            _run(sql, max_verification_cost=0.05)
+        except SUQLCostLimitExceeded:
+            assert llm.calls * 0.01 <= 0.05 + 0.01, llm.calls
+            return
+    raise AssertionError("expected SUQLCostLimitExceeded")
+
+
+def check_the_default_ceiling_is_active_without_being_asked():
+    """A caller who passes nothing still gets a ceiling - that is the whole
+    point, since the runaway happened with no ceiling configured."""
+    with _MeteredLLM(cost_per_call=0.5) as llm:
+        try:
+            _run(_BROAD)
+        except SUQLCostLimitExceeded as e:
+            assert "1.00" in str(e), str(e)
+            assert llm.calls <= 3, llm.calls
+            return
+    raise AssertionError("expected the default $1.00 ceiling to apply")
+
+
+INTEGRATION_CHECKS = [
+    check_runaway_query_is_refused_cheaply,
+    check_affordable_query_completes_and_reports_spend,
+    check_ceiling_can_be_disabled,
+    check_call_ceiling_applies_end_to_end,
+    check_where_clause_verification_is_also_capped,
+    check_the_default_ceiling_is_active_without_being_asked,
+]
+
+
+# ---------- runner ------------------------------------------------------------
+
+def main():
+    failures = []
+    print("--- unit ---")
+    for check in UNIT_CHECKS:
+        try:
+            check()
+            print("[PASS] {}".format(check.__name__))
+        except Exception:
+            print("[FAIL] {}".format(check.__name__))
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    print("\n--- integration (real acled DB, metered fake LLM) ---")
+    for check in INTEGRATION_CHECKS:
+        try:
+            check()
+            print("[PASS] {}".format(check.__name__))
+        except Exception:
+            print("[FAIL] {}".format(check.__name__))
+            traceback.print_exc()
+            failures.append(check.__name__)
+
+    if failures:
+        print("\n{} failed: {}".format(len(failures), failures))
+        sys.exit(1)
+    print("\nall checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #58. Closes #59. Releases `1.1.10a4`.

Stacked on #56 — until that merges, the commit list here shows its commit too. Once #56 lands, this reduces to the three commits below.

> [!IMPORTANT]
> **This changes a default.** `answer()` verification is now capped at **$1.00 per query**. A query that previously ran to completion while spending more now raises `SUQLCostLimitExceeded` instead of returning results. Pass `max_verification_cost=<usd>` to raise the ceiling, or `0` to restore the previous unbounded behaviour.

---

## #58 — CTE materialization loses information the rest of the query needs

Four failures from one reported run in which 12/12 SUQL executions failed. All are the same mistake in different places: a CTE containing `answer()` is materialized into a temp table, and something the rest of the query needs does not survive the boundary.

**The name the CTE is referred to by.** `_rewrite_cte_refs` replaced `RangeVar.relname` with the temp table name and kept nothing, so `SELECT base.id ... FROM base` became `... FROM temp_table_xxx` → `missing FROM-clause entry for table "base"`. An explicit alias (`FROM base b` … `SELECT b.*`) survived that step but was then overwritten in `visit_SelectStmt`, which aliased the temp table to its own relname. The referenced name is now kept as an alias, and an existing alias is carried across rather than replaced. The real-table path is unchanged: `_replace_table_aliases` clears the alias and rewrites references to the table name, so the existing fallback still applies there.

**The CTE's own output columns.** A CTE counted as "materialized" whenever its FROM clause named a temp table — also true when it merely *reads* from an upstream CTE's temp table. Downstream references were redirected there, bypassing this CTE's projection entirely → `column "..." does not exist`. Redirection now requires the body to actually reduce to `SELECT * FROM <temp table>`; when it doesn't, the body's own output is materialized first.

**The row ID.** A CTE that doesn't project its source table's ID column left `_infer_cte_id_column` with nothing to register, and a downstream `answer()` died on `table_w_ids[relname]` with a bare `KeyError: 'temp_table_xxx'`. The ID is now added back before such a CTE is materialized — restricted to CTEs materialized as *input* to a later `answer()`, since one carrying `answer()` itself is built by `_execute_structural_sql`, whose `SELECT *` already brings the ID across. That restriction also keeps the added column out of the user's own projection, so `SELECT * FROM <cte>` still returns exactly what was asked for. (My first attempt didn't, and a test caught it.)

**Genuinely ID-less CTEs.** One that aggregates has no row to identify and no projected ID can fix it. `_retrieve_and_verify` now raises an actionable `NotImplementedError` naming the relation and the available ID columns.

Verified against the reported queries on a live 1.6M-row table:

| | Was | Now |
|---|---|---|
| Q1 | `missing FROM-clause entry for table "b"` after 602s | 24 rows |
| Q2 | `maximum recursion depth exceeded` | 24 rows |
| Q4 | `KeyError: 'temp_table_3vscmkujhxbx'` | 59 rows |
| Q7 | `column "russian_yes" does not exist` | runs; correct on a scaled-down copy of the shape through the real UDF |

One honest caveat: I could not reproduce the `maximum recursion depth exceeded` message that Q2 was reported to produce, at any commit or scale — I get the alias error at the same ~0.3s timing. This fixes the query *shape*; I have no evidence it fixes #46, which stays open with a [comment](https://github.com/stanford-oval/suql/issues/46#issuecomment-5259370726) recording that.

## #59 — unbounded verification cost

Nothing bounded what one query could spend. A reported run ground for 25 hours on 4,326,211 verification calls costing $101.51 with **zero** queries completing. `statement_timeout` doesn't apply — `_verify` runs client-side. Parallelising verification made it faster, not cheaper.

Enforced in `_verify`, the one point every compiler-side verification passes through, so it covers the retriever-backed WHERE path and projection predicates alike. The budget lives on a `ContextVar`, already propagated into the worker threads by `contextvars.copy_context()`.

Two mechanisms, because a ceiling alone isn't enough:

- **Stop** — accumulated spend is checked before every verification, so a query can never run past its ceiling.
- **Refuse early** — a query planning millions of verifications shouldn't spend the whole ceiling discovering that. After 25 real calls the mean cost per verification is extrapolated over the number still planned. At the reported rate ($101.51 / 4.3M = $0.0000235 per call), a 176,660-verification plan is now refused in **11.7s having spent $0.0006**:

```
refusing to continue: 176,660 verifications are planned and the first 26 cost
$0.0006 ($0.000023 each), so this query projects to $3.99 - over the $1.00 limit.
Narrow the query with structural predicates, add a LIMIT, or raise
max_verification_cost.
```

The same predicate scoped to 5,000 rows still completes normally ($0.117).

Exceeding the ceiling raises `SUQLCostLimitExceeded` (exported from `suql`) rather than returning a half-applied filter as though it were the whole answer — a partial free-text filter is a wrong answer, not a partial one.

Cost is projected per verification *attempt*, not per LLM call, so documents served from the `_verified_res` memo cache don't inflate the estimate. The planned count for a multi-predicate WHERE is an upper bound (`_verify_single_res` short-circuits), so the projection errs toward refusing; the message says how to raise the ceiling. `max_verification_calls` caps call count instead. Both override process-wide via `SUQL_MAX_VERIFICATION_COST` / `SUQL_MAX_VERIFICATION_CALLS`. `cache["_stats"]` now also reports `verifications` and `max_verification_cost`.

**Scope, stated plainly:** this bounds spend made in the SUQL process. `answer()` left in a projection for Postgres to run as the raw plpython3u UDF calls the free-text server directly and cannot be stopped from here — that needs a server-side budget keyed on `query_id`, tracked in #59. The ceiling is also per `suql_execute` call, so a pipeline issuing many queries still needs an aggregate budget of its own.

## Testing

Two new suites, both against the live DB:

- `tests/test_cte_answer_regressions.py` — 5 unit + 7 integration checks, asserting **results** rather than absence of the original error. Includes a check that the re-added ID column doesn't leak into `SELECT * FROM <cte>`.
- `tests/test_verification_budget.py` — 7 unit + 6 integration checks. These stub `llm_generate` rather than `_verify`, so the real `_verify` runs with its budget check while each call books a known cost — that's what lets them assert *how much* was spent before the stop, not just that one happened. Covers the ceiling, the projection, the call cap, cache accounting, disabling, the WHERE path, and that a caller who passes nothing still gets the default.

All existing suites pass. `tests/test_cte_materialization.py` output is byte-identical to the pre-change baseline (its integration half needs live LLM credentials, which this box lacks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
